### PR TITLE
fix: sandbox tile highlight

### DIFF
--- a/packages/frontend/src/routes/SandboxRoute.tsx
+++ b/packages/frontend/src/routes/SandboxRoute.tsx
@@ -269,7 +269,7 @@ function SandboxRoute() {
         resetView
     } = useGameBoard({
         gameState: gameState,
-        highlightedCells: gameState.winner?.cells ?? "last",
+        highlightedCells: gameState.winner?.cells ?? "turn",
         localPlayerId,
         interactionEnabled: isSandboxInteractionEnabled,
         onPlaceCell: gameState.winner === null ? handlePlaceCell : undefined,


### PR DESCRIPTION
In the sandbox only the last turn was displayed leading to confusion when playing bigger boards against the bots as they move almost instantly.

Now highlights both moves made in a turn.