### PR TITLE
Fix inconsistent background color in sandbox welcome & import modal pages

### DIFF
--- a/packages/frontend/src/routes/SandboxRoute.tsx
+++ b/packages/frontend/src/routes/SandboxRoute.tsx
@@ -701,8 +701,8 @@ function SandboxRoute() {
                         })}
             />
 
-            <div className="relative h-full w-full overflow-hidden bg-slate-950 text-white">
-                {!isImportModalOpen && (
+            <div className="relative h-full w-full overflow-hidden text-white">
+                {!isWelcomeModalVisible && !isImportModalOpen && (
                     <GameBoardCanvas
                         canvasRef={canvasRef}
                         className={canvasClassName}


### PR DESCRIPTION
Fixes #52.
The canvas and the `bg-slate-950` background were hiding the gradient.