### PR TITLE
various fixes for the tournament system

### DIFF
--- a/packages/backend/src/dev/devSupportService.ts
+++ b/packages/backend/src/dev/devSupportService.ts
@@ -7,6 +7,7 @@ import type {
     GameState,
     HexCoordinate,
     TournamentDetail,
+    TournamentFormat,
     TournamentMatch,
     TournamentParticipant,
 } from '@ih3t/shared';
@@ -128,15 +129,24 @@ export class DevSupportService {
     }
 
     async createQuickSealBotTournament(actor: AccountUserProfile): Promise<TournamentDetail> {
+        return this.createQuickSealBotTournamentWithOptions(actor, `double-elimination`, kQuickSealBotTournamentEntrants);
+    }
+
+    async createQuickSealBotTournamentWithOptions(
+        actor: AccountUserProfile,
+        format: TournamentFormat,
+        playerCount: number,
+    ): Promise<TournamentDetail> {
         this.assertEnabled();
 
+        const formatLabel = format === `swiss` ? `Swiss` : format === `single-elimination` ? `SE` : `DE`;
         const request: CreateTournamentRequest = {
-            name: `Seal Bot Test ${new Date().toLocaleTimeString()}`,
-            format: `double-elimination`,
+            name: `${formatLabel} ${playerCount}P Seal Bot ${new Date().toLocaleTimeString()}`,
+            format,
             visibility: `private`,
             scheduledStartAt: Date.now() + 60_000,
             checkInWindowMinutes: 5,
-            maxPlayers: kQuickSealBotTournamentEntrants,
+            maxPlayers: playerCount,
             timeControl: { mode: `turn`, turnTimeMs: 20_000 },
             seriesSettings: {
                 earlyRoundsBestOf: 1,
@@ -149,7 +159,7 @@ export class DevSupportService {
 
         const createdTournament = await this.tournamentService.createTournament(actor, request);
         await this.seedTournament(createdTournament.id, actor, {
-            count: kQuickSealBotTournamentEntrants,
+            count: playerCount,
             state: `checked-in`,
         });
         await this.tournamentService.startTournament(createdTournament.id, actor);

--- a/packages/backend/src/network/cors.ts
+++ b/packages/backend/src/network/cors.ts
@@ -20,7 +20,9 @@ export class CorsConfiguration {
         if (process.env.NODE_ENV !== `production`) {
             allowedOrigins.add(`http://localhost:3001`);
             allowedOrigins.add(`http://localhost:5173`);
+            allowedOrigins.add(`http://localhost:5174`);
             allowedOrigins.add(`http://127.0.0.1:5173`);
+            allowedOrigins.add(`http://127.0.0.1:5174`);
         }
 
         return allowedOrigins;

--- a/packages/backend/src/network/createSocketServer.test.ts
+++ b/packages/backend/src/network/createSocketServer.test.ts
@@ -495,7 +495,7 @@ test(`watch-session can follow multiple rooms and unwatch stops further updates`
                     matchJoinTimeoutMs: 300_000,
                     matchExtensionMs: 300_000,
                     pendingExtension: false,
-                    matchStartedAt: 1_700_000_000_000,
+                    matchJoinTimeoutInMs: 300_000,
                     leftDisplayName: `Alpha`,
                     rightDisplayName: `Bravo`,
                     leftProfileId: `profile-alpha`,

--- a/packages/backend/src/network/createSocketServer.test.ts
+++ b/packages/backend/src/network/createSocketServer.test.ts
@@ -494,6 +494,7 @@ test(`watch-session can follow multiple rooms and unwatch stops further updates`
                     rightWins: 0,
                     matchJoinTimeoutMs: 300_000,
                     matchExtensionMs: 300_000,
+                    pendingExtension: false,
                     matchStartedAt: 1_700_000_000_000,
                     leftDisplayName: `Alpha`,
                     rightDisplayName: `Bravo`,

--- a/packages/backend/src/network/createSocketServer.test.ts
+++ b/packages/backend/src/network/createSocketServer.test.ts
@@ -498,6 +498,8 @@ test(`watch-session can follow multiple rooms and unwatch stops further updates`
                     matchStartedAt: 1_700_000_000_000,
                     leftDisplayName: `Alpha`,
                     rightDisplayName: `Bravo`,
+                    leftProfileId: `profile-alpha`,
+                    rightProfileId: `profile-bravo`,
                 },
             });
             harness.sessionManager.emitGameState(liveSessionB.id, {

--- a/packages/backend/src/network/rest/createApiRouter.ts
+++ b/packages/backend/src/network/rest/createApiRouter.ts
@@ -426,6 +426,32 @@ export class ApiRouter {
                     throw error;
                 }
             });
+
+            router.post(`/dev/tournaments/quick-seal-bot-16/:format`, async (req, res) => {
+                const user = await this.authService.getUserFromRequest(req);
+                if (!user) {
+                    res.status(401).json({ error: `Sign in before using development tournament helpers.` });
+                    return;
+                }
+
+                const format = req.params.format;
+                if (format !== `swiss` && format !== `single-elimination` && format !== `double-elimination`) {
+                    res.status(400).json({ error: `Invalid format. Use swiss, single-elimination, or double-elimination.` });
+                    return;
+                }
+
+                try {
+                    const tournament = await this.devSupportService.createQuickSealBotTournamentWithOptions(user, format, 16);
+                    res.json({ tournament });
+                } catch (error: unknown) {
+                    if (error instanceof SessionError) {
+                        res.status(409).json({ error: error.message });
+                        return;
+                    }
+
+                    throw error;
+                }
+            });
         }
 
         router.post(`/tournaments`, express.json(), async (req, res) => {

--- a/packages/backend/src/session/sessionManager.ts
+++ b/packages/backend/src/session/sessionManager.ts
@@ -1191,6 +1191,13 @@ export class SessionManager {
         }
     }
 
+    clearSessionTournamentInfo(sessionId: string): void {
+        const session = this.sessions.get(sessionId);
+        if (session) {
+            session.tournament = null;
+        }
+    }
+
     requireSession(sessionId: string): ServerGameSession {
         const session = this.sessions.get(sessionId);
         if (!session) {

--- a/packages/backend/src/tournament/tournamentRepository.ts
+++ b/packages/backend/src/tournament/tournamentRepository.ts
@@ -154,6 +154,7 @@ export class TournamentRepository {
                     ? [
                         { 'participants.profileId': profileId },
                         { createdByProfileId: profileId },
+                        { organizers: profileId },
                         { subscriberProfileIds: profileId },
                     ]
                     : []),
@@ -195,6 +196,7 @@ export class TournamentRepository {
             $or: [
                 { 'participants.profileId': profileId },
                 { createdByProfileId: profileId },
+                { organizers: profileId },
                 { subscriberProfileIds: profileId },
             ],
         })

--- a/packages/backend/src/tournament/tournamentRepository.ts
+++ b/packages/backend/src/tournament/tournamentRepository.ts
@@ -146,8 +146,14 @@ export class TournamentRepository {
         pageSize: number,
     ): Promise<{ tournaments: TournamentRecord[]; total: number }> {
         const collection = await this.getCollection();
+        const pastStatuses = [
+            `completed`,
+            `cancelled`,
+        ] as const;
         const filter = {
-            status: `completed` as const,
+            status: {
+                $in: pastStatuses,
+            },
             $or: [
                 { isPublished: true },
                 ...(profileId
@@ -163,7 +169,11 @@ export class TournamentRepository {
 
         const [documents, total] = await Promise.all([
             collection.find(filter)
-                .sort({ completedAt: -1 })
+                .sort({
+                    completedAt: -1,
+                    cancelledAt: -1,
+                    updatedAt: -1,
+                })
                 .skip((page - 1) * pageSize)
                 .limit(pageSize)
                 .toArray(),

--- a/packages/backend/src/tournament/tournamentService.test.ts
+++ b/packages/backend/src/tournament/tournamentService.test.ts
@@ -1732,7 +1732,8 @@ test(`best-of follow-up games reset startedAt and the session tournament timer`,
 
     assert.ok(gameTwoMatch.sessionId);
     assert.notEqual(gameTwoMatch.startedAt, 1);
-    assert.equal(gameTwoSession?.tournament?.matchStartedAt, gameTwoMatch.startedAt);
+    const remainingMs = gameTwoSession?.tournament?.matchJoinTimeoutInMs;
+    assert.ok(typeof remainingMs === `number` && remainingMs > 0);
     assert.equal(gameTwoSession?.tournament?.currentGameNumber, 2);
     assert.equal(gameTwoSession?.tournament?.leftWins, 1);
     assert.equal(gameTwoSession?.tournament?.rightWins, 0);
@@ -1909,7 +1910,7 @@ test(`claimWin ignores approved extensions from earlier best-of games`, async ()
     const claim = await service.claimWin(tournament.id, `match-winners-1-1`, user);
     assert.equal(claim.matchId, `match-winners-1-1`);
     assert.equal(claim.gameNumber, 2);
-    assert.ok(claim.expiresAt > claim.startedAt);
+    assert.ok(claim.expiresInMs > 0);
 
     (service as unknown as {
         cancelClaimWin: (matchId: string, sessionId: string) => void;

--- a/packages/backend/src/tournament/tournamentService.test.ts
+++ b/packages/backend/src/tournament/tournamentService.test.ts
@@ -195,6 +195,31 @@ class FakeTournamentRepository {
     async removeSubscriber(): Promise<void> { }
 }
 
+class DelayedDetailSaveTournamentRepository extends FakeTournamentRepository {
+    private staleSaveStartedResolver: (() => void) | null = null;
+    private releaseStaleSaveResolver: (() => void) | null = null;
+    readonly staleSaveStarted = new Promise<void>((resolve) => {
+        this.staleSaveStartedResolver = resolve;
+    });
+    private readonly releaseStaleSave = new Promise<void>((resolve) => {
+        this.releaseStaleSaveResolver = resolve;
+    });
+
+    allowStaleSave(): void {
+        this.releaseStaleSaveResolver?.();
+    }
+
+    override async saveTournament(tournament: TournamentRecord): Promise<void> {
+        const timedOutMatch = tournament.matches.find((match) => match.id === `match-swiss-1-1`);
+        if (timedOutMatch?.state === `in-progress`) {
+            this.staleSaveStartedResolver?.();
+            await this.releaseStaleSave;
+        }
+
+        await super.saveTournament(tournament);
+    }
+}
+
 type FakeSession = {
     id: string;
     players: Array<{
@@ -257,6 +282,7 @@ class FakeGameHistoryRepository {
 
 class FakeTournamentEventSink {
     readonly tournamentNotifications: Array<{ profileId: string; kind: string }> = [];
+    readonly sessionClaimWins: Array<{ sessionId: string; state: unknown | null }> = [];
 
     tournamentUpdated(): void { }
 
@@ -264,7 +290,12 @@ class FakeTournamentEventSink {
         this.tournamentNotifications.push({ profileId, kind: event.kind });
     }
 
-    sessionClaimWin(): void { }
+    sessionClaimWin(event: { sessionId: string; state: unknown | null }): void {
+        this.sessionClaimWins.push({
+            sessionId: event.sessionId,
+            state: event.state,
+        });
+    }
 
     sessionUpdated(): void { }
 }
@@ -286,6 +317,30 @@ function createService(initialTournament: TournamentRecord) {
     const repository = new FakeTournamentRepository(initialTournament);
     const sessionManager = new FakeSessionManager();
     const eventSink = new FakeTournamentEventSink();
+    const service = new TournamentService(
+        repository as never,
+        {} as never,
+        sessionManager as never,
+        new FakeGameHistoryRepository() as never,
+    );
+    service.setEventHandlers(eventSink);
+
+    return {
+        repository,
+        sessionManager,
+        eventSink,
+        service,
+    };
+}
+
+function createServiceWithOverrides(options: {
+    repository: FakeTournamentRepository;
+    sessionManager?: FakeSessionManager;
+    eventSink?: FakeTournamentEventSink;
+}) {
+    const repository = options.repository;
+    const sessionManager = options.sessionManager ?? new FakeSessionManager();
+    const eventSink = options.eventSink ?? new FakeTournamentEventSink();
     const service = new TournamentService(
         repository as never,
         {} as never,
@@ -973,4 +1028,119 @@ test(`claimWin ignores approved extensions from earlier best-of games`, async ()
     (service as unknown as {
         cancelClaimWin: (matchId: string, sessionId: string) => void;
     }).cancelClaimWin(`match-winners-1-1`, `session-2`);
+});
+
+test(`resolveClaimWin clears the session claim state after awarding the walkover`, async () => {
+    const user = createAccountUser({ id: `player-1`, username: `Player 1` });
+    const now = Date.now();
+    const tournament = createTournament({
+        status: `live`,
+        format: `single-elimination`,
+        matchJoinTimeoutMinutes: 5,
+        participants: [
+            createParticipant({ profileId: user.id, displayName: user.username, registeredAt: 1, checkedInAt: 1, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 2, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `in-progress`,
+                sessionId: `session-claim`,
+                startedAt: now - 10 * 60_000,
+                slots: [
+                    createSlot({ profileId: user.id, displayName: user.username, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+    });
+    const { service, repository, sessionManager, eventSink } = createService(tournament);
+    sessionManager.sessions.set(`session-claim`, {
+        id: `session-claim`,
+        players: [
+            { id: `session-claim-player-1`, profileId: user.id, connection: { status: `connected` } },
+            { id: `session-claim-player-2`, profileId: `player-2`, connection: { status: `disconnected` } },
+        ],
+        state: { status: `lobby` },
+        tournament: null,
+    });
+
+    await service.claimWin(tournament.id, `match-winners-1-1`, user);
+    await (service as unknown as {
+        resolveClaimWin: (tournamentId: string, matchId: string) => Promise<void>;
+    }).resolveClaimWin(tournament.id, `match-winners-1-1`);
+
+    const stored = repository.getSync(tournament.id);
+    const match = stored.matches.find((entry) => entry.id === `match-winners-1-1`);
+    const clearEvent = eventSink.sessionClaimWins.at(-1);
+
+    assert.equal(match?.state, `completed`);
+    assert.equal(match?.winnerProfileId, user.id);
+    assert.deepEqual(clearEvent, {
+        sessionId: `session-claim`,
+        state: null,
+    });
+});
+
+test(`getTournamentDetail does not overwrite a newer live tournament update`, async () => {
+    const organizer = createAccountUser({ id: `organizer-1`, username: `Organizer` });
+    const tournament = createTournament({
+        status: `live`,
+        format: `swiss`,
+        matchJoinTimeoutMinutes: 5,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 11, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 12, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-swiss-1-1`,
+                bracket: `swiss`,
+                round: 1,
+                order: 1,
+                state: `in-progress`,
+                startedAt: Date.now() - 10 * 60_000,
+                sessionId: `session-timeout-race`,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+    });
+    const repository = new DelayedDetailSaveTournamentRepository(tournament);
+    const sessionManager = new FakeSessionManager();
+    sessionManager.sessions.set(`session-timeout-race`, {
+        id: `session-timeout-race`,
+        players: [
+            { id: `p1`, profileId: `player-1`, connection: { status: `connected` } },
+            { id: `p2`, profileId: `player-2`, connection: { status: `disconnected` } },
+        ],
+        state: { status: `lobby` },
+        tournament: null,
+    });
+    const { service } = createServiceWithOverrides({
+        repository,
+        sessionManager,
+    });
+
+    const detailPromise = service.getTournamentDetail(tournament.id, null);
+    await repository.staleSaveStarted;
+
+    const awardPromise = service.awardWalkover(tournament.id, `match-swiss-1-1`, `player-1`, organizer);
+
+    repository.allowStaleSave();
+    await Promise.all([
+        detailPromise,
+        awardPromise,
+    ]);
+
+    const stored = repository.getSync(tournament.id);
+    const match = stored.matches.find((entry) => entry.id === `match-swiss-1-1`);
+
+    assert.equal(match?.state, `completed`);
+    assert.equal(match?.winnerProfileId, `player-1`);
 });

--- a/packages/backend/src/tournament/tournamentService.test.ts
+++ b/packages/backend/src/tournament/tournamentService.test.ts
@@ -150,6 +150,42 @@ class FakeTournamentRepository {
         return tournament ? structuredClone(tournament) : null;
     }
 
+    async listPublishedTournaments(): Promise<TournamentRecord[]> {
+        return [...this.tournaments.values()]
+            .filter((tournament) => tournament.isPublished)
+            .map((tournament) => structuredClone(tournament));
+    }
+
+    async listTournamentsForPlayer(userId: string): Promise<TournamentRecord[]> {
+        return [...this.tournaments.values()]
+            .filter((tournament) =>
+                tournament.createdByProfileId === userId
+                || tournament.participants.some((participant) => participant.profileId === userId))
+            .map((tournament) => structuredClone(tournament));
+    }
+
+    async listPastTournaments(_userId: string | null, _page: number, limit: number): Promise<{ tournaments: TournamentRecord[]; total: number }> {
+        const tournaments = [...this.tournaments.values()]
+            .filter((tournament) => tournament.status === `completed` || tournament.status === `cancelled`)
+            .sort((left, right) => (right.completedAt ?? right.updatedAt) - (left.completedAt ?? left.updatedAt));
+        return {
+            tournaments: tournaments.slice(0, limit).map((tournament) => structuredClone(tournament)),
+            total: tournaments.length,
+        };
+    }
+
+    async getCompletedTournamentsForPlayer(userId: string): Promise<TournamentRecord[]> {
+        return [...this.tournaments.values()]
+            .filter((tournament) =>
+                tournament.status === `completed`
+                && tournament.participants.some((participant) => participant.profileId === userId))
+            .map((tournament) => structuredClone(tournament));
+    }
+
+    async countTournamentsCreatedByUser(userId: string): Promise<number> {
+        return [...this.tournaments.values()].filter((tournament) => tournament.createdByProfileId === userId).length;
+    }
+
     async listReconciliableTournaments(): Promise<TournamentRecord[]> {
         return [...this.tournaments.values()].map((tournament) => structuredClone(tournament));
     }
@@ -454,6 +490,52 @@ test(`single-elimination standings rank the third-place winner ahead of the lose
     assert.equal(fourthPlaceStanding?.rank, 4);
 });
 
+test(`listTournaments reports best placement for underfilled single-elimination champions`, async () => {
+    const champion = createAccountUser({ id: `player-1`, username: `Champion` });
+    const runnerUp = createAccountUser({ id: `player-2`, username: `Runner Up` });
+    const participants = Array.from({ length: 8 }, (_, index) =>
+        createParticipant({
+            profileId: `player-${index + 1}`,
+            displayName: `Player ${index + 1}`,
+            registeredAt: index + 1,
+            checkedInAt: index + 11,
+            status: index === 0 ? `completed` : `eliminated`,
+            checkInState: `checked-in`,
+            seed: index + 1,
+        }));
+    const tournament = createTournament({
+        status: `completed`,
+        format: `single-elimination`,
+        maxPlayers: 16,
+        completedAt: 100,
+        participants,
+        matches: [
+            createMatch({
+                id: `match-winners-3-1`,
+                bracket: `winners`,
+                round: 3,
+                order: 1,
+                state: `completed`,
+                winnerProfileId: champion.id,
+                loserProfileId: runnerUp.id,
+                resolvedAt: 100,
+                slots: [
+                    createSlot({ profileId: champion.id, displayName: champion.username, seed: 1 }),
+                    createSlot({ profileId: runnerUp.id, displayName: runnerUp.username, seed: 2 }),
+                ],
+            }),
+        ],
+    });
+    const { service } = createService(tournament);
+
+    const championListing = await service.listTournaments(champion);
+    const runnerUpListing = await service.listTournaments(runnerUp);
+
+    assert.equal(championListing.stats?.bestPlacement?.rank, 1);
+    assert.equal(championListing.stats?.bestPlacement?.tournamentName, tournament.name);
+    assert.equal(runnerUpListing.stats?.bestPlacement?.rank, 2);
+});
+
 test(`swiss tournaments can start with two checked-in players`, async () => {
     const organizer = createAccountUser({ id: `organizer-1`, username: `Organizer` });
     const tournament = createTournament({
@@ -583,6 +665,82 @@ test(`reconcileAllTournaments only records one timeout warning per timeout windo
     const stored = repository.getSync(tournament.id);
     const timeoutWarnings = stored.activity.filter((entry) => entry.type === `timeout-warning`);
     assert.equal(timeoutWarnings.length, 1);
+});
+
+test(`reconcileAllTournaments records separate timeout warnings for winners and losers bracket matches`, async () => {
+    const matchStartedAt = Date.now() - 10 * 60_000;
+    const tournament = createTournament({
+        status: `live`,
+        format: `double-elimination`,
+        matchJoinTimeoutMinutes: 5,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 11, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 12, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+            createParticipant({ profileId: `player-3`, displayName: `Player 3`, registeredAt: 3, checkedInAt: 13, status: `checked-in`, checkInState: `checked-in`, seed: 3 }),
+            createParticipant({ profileId: `player-4`, displayName: `Player 4`, registeredAt: 4, checkedInAt: 14, status: `checked-in`, checkInState: `checked-in`, seed: 4 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `in-progress`,
+                startedAt: matchStartedAt,
+                sessionId: `session-timeout-winners`,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+            createMatch({
+                id: `match-losers-1-1`,
+                bracket: `losers`,
+                round: 1,
+                order: 1,
+                state: `in-progress`,
+                startedAt: matchStartedAt,
+                sessionId: `session-timeout-losers`,
+                slots: [
+                    createSlot({ profileId: `player-3`, displayName: `Player 3`, seed: 3 }),
+                    createSlot({ profileId: `player-4`, displayName: `Player 4`, seed: 4 }),
+                ],
+            }),
+        ],
+    });
+    const { service, repository, sessionManager, eventSink } = createService(tournament);
+    sessionManager.sessions.set(`session-timeout-winners`, {
+        id: `session-timeout-winners`,
+        players: [
+            { id: `w1`, profileId: `player-1`, connection: { status: `connected` } },
+            { id: `w2`, profileId: `player-2`, connection: { status: `disconnected` } },
+        ],
+        state: { status: `lobby` },
+        tournament: null,
+    });
+    sessionManager.sessions.set(`session-timeout-losers`, {
+        id: `session-timeout-losers`,
+        players: [
+            { id: `l1`, profileId: `player-3`, connection: { status: `connected` } },
+            { id: `l2`, profileId: `player-4`, connection: { status: `disconnected` } },
+        ],
+        state: { status: `lobby` },
+        tournament: null,
+    });
+
+    await service.reconcileAllTournaments();
+
+    const stored = repository.getSync(tournament.id);
+    const timeoutWarnings = stored.activity.filter((entry) => entry.type === `timeout-warning`);
+    assert.equal(timeoutWarnings.length, 2);
+    assert.deepEqual(
+        timeoutWarnings.map((entry) => entry.message).sort(),
+        [
+            `Losers R1 M1 timed out — waiting for player(s) to join.`,
+            `Winners R1 M1 timed out — waiting for player(s) to join.`,
+        ],
+    );
+    assert.equal(eventSink.tournamentNotifications.filter((entry) => entry.kind === `timeout-warning`).length, 2);
 });
 
 test(`best-of follow-up games reset startedAt and the session tournament timer`, async () => {

--- a/packages/backend/src/tournament/tournamentService.test.ts
+++ b/packages/backend/src/tournament/tournamentService.test.ts
@@ -556,6 +556,59 @@ test(`swiss tournaments can start with two checked-in players`, async () => {
     assert.equal(detail.matches[0]?.bracket, `swiss`);
 });
 
+test(`waitlist timeout starts the tournament cleanly after replacement check-ins`, async () => {
+    const tournament = createTournament({
+        status: `waitlist-open`,
+        format: `swiss`,
+        maxPlayers: 3,
+        swissRoundCount: 1,
+        waitlistEnabled: true,
+        waitlistClosesAt: Date.now() - 1_000,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 11, status: `checked-in`, checkInState: `checked-in` }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 12, status: `checked-in`, checkInState: `checked-in` }),
+            createParticipant({ profileId: `player-3`, displayName: `Player 3`, registeredAt: 3, status: `waitlisted`, checkInState: `not-open` }),
+        ],
+    });
+    const { service, repository } = createService(tournament);
+
+    await service.reconcileAllTournaments();
+
+    const stored = repository.getSync(tournament.id);
+    assert.equal(stored.status, `live`);
+    assert.equal(stored.waitlistOpensAt, null);
+    assert.equal(stored.waitlistClosesAt, null);
+    assert.equal(stored.matches.length, 1);
+    assert.equal(stored.matches[0]?.bracket, `swiss`);
+    assert.equal(stored.participants.find((participant) => participant.profileId === `player-3`)?.status, `dropped`);
+});
+
+test(`waitlist check-in rejects attempts after the waitlist window closes`, async () => {
+    const player = createAccountUser({ id: `player-3`, username: `Player 3` });
+    const tournament = createTournament({
+        status: `waitlist-open`,
+        waitlistEnabled: true,
+        maxPlayers: 2,
+        waitlistClosesAt: Date.now() - 1_000,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 11, status: `checked-in`, checkInState: `checked-in` }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkInState: `missed`, status: `dropped`, removedAt: 22 }),
+            createParticipant({ profileId: player.id, displayName: player.username, registeredAt: 3, status: `waitlisted`, checkInState: `not-open` }),
+        ],
+    });
+    const { service, repository } = createService(tournament);
+
+    await assert.rejects(
+        () => service.checkInCurrentUser(tournament.id, player),
+        /Waitlist check-in has closed/,
+    );
+
+    const stored = repository.getSync(tournament.id);
+    const waitlistedParticipant = stored.participants.find((participant) => participant.profileId === player.id);
+    assert.equal(waitlistedParticipant?.status, `waitlisted`);
+    assert.equal(waitlistedParticipant?.checkedInAt, null);
+});
+
 test(`viewer state hides register and waitlist actions for ineligible users`, async () => {
     const outsider = createAccountUser({ id: `player-out`, username: `Outsider` });
     const whitelistTournament = createTournament({

--- a/packages/backend/src/tournament/tournamentService.test.ts
+++ b/packages/backend/src/tournament/tournamentService.test.ts
@@ -584,3 +584,182 @@ test(`reconcileAllTournaments only records one timeout warning per timeout windo
     const timeoutWarnings = stored.activity.filter((entry) => entry.type === `timeout-warning`);
     assert.equal(timeoutWarnings.length, 1);
 });
+
+test(`best-of follow-up games reset startedAt and the session tournament timer`, async () => {
+    const tournament = createTournament({
+        status: `live`,
+        format: `single-elimination`,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 1, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 2, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `ready`,
+                bestOf: 3,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+    });
+    const { service, repository, sessionManager } = createService(tournament);
+
+    await service.reconcileAllTournaments();
+    let stored = repository.getSync(tournament.id);
+    assert.ok(stored.matches[0]?.sessionId);
+    const gameOneSessionId = stored.matches[0]!.sessionId!;
+
+    // Force a known stale timer so the next game's reset is easy to prove.
+    stored.matches[0]!.startedAt = 1;
+    repository.saveSync(stored);
+
+    const gameOneSession = sessionManager.sessions.get(gameOneSessionId);
+    assert.ok(gameOneSession?.players[0]);
+    gameOneSession.state = {
+        status: `finished`,
+        gameId: `game-1`,
+        winningPlayerId: gameOneSession.players[0].id,
+    };
+
+    await service.reconcileAllTournaments();
+    stored = repository.getSync(tournament.id);
+    assert.equal(stored.matches[0]?.state, `ready`);
+    assert.equal(stored.matches[0]?.currentGameNumber, 2);
+    assert.equal(stored.matches[0]?.startedAt, null);
+
+    await service.reconcileAllTournaments();
+    stored = repository.getSync(tournament.id);
+    const gameTwoMatch = stored.matches[0]!;
+    const gameTwoSession = sessionManager.sessions.get(gameTwoMatch.sessionId!);
+
+    assert.ok(gameTwoMatch.sessionId);
+    assert.notEqual(gameTwoMatch.startedAt, 1);
+    assert.equal(gameTwoSession?.tournament?.matchStartedAt, gameTwoMatch.startedAt);
+    assert.equal(gameTwoSession?.tournament?.currentGameNumber, 2);
+    assert.equal(gameTwoSession?.tournament?.leftWins, 1);
+    assert.equal(gameTwoSession?.tournament?.rightWins, 0);
+});
+
+test(`requestExtension is scoped to the current best-of game`, async () => {
+    const user = createAccountUser({ id: `player-1`, username: `Player 1` });
+    const tournament = createTournament({
+        status: `live`,
+        format: `single-elimination`,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 1, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 2, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `ready`,
+                bestOf: 3,
+                currentGameNumber: 2,
+                leftWins: 1,
+                rightWins: 0,
+                gameIds: [`game-1`],
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+        extensionRequests: [
+            {
+                id: `extension-g1`,
+                matchId: `match-winners-1-1`,
+                gameNumber: 1,
+                requestedByProfileId: user.id,
+                requestedByDisplayName: user.username,
+                requestedAt: Date.now() - 60_000,
+                status: `denied`,
+                resolvedByProfileId: `organizer-1`,
+                resolvedAt: Date.now() - 30_000,
+            },
+        ],
+    });
+    const { service } = createService(tournament);
+
+    const detail = await service.requestExtension(tournament.id, `match-winners-1-1`, user);
+    const currentGameExtensions = detail.extensionRequests.filter((request) =>
+        request.matchId === `match-winners-1-1` && request.gameNumber === 2 && request.requestedByProfileId === user.id);
+
+    assert.equal(currentGameExtensions.length, 1);
+    assert.equal(currentGameExtensions[0]?.status, `pending`);
+});
+
+test(`claimWin ignores approved extensions from earlier best-of games`, async () => {
+    const user = createAccountUser({ id: `player-1`, username: `Player 1` });
+    const now = Date.now();
+    const tournament = createTournament({
+        status: `live`,
+        format: `single-elimination`,
+        matchJoinTimeoutMinutes: 5,
+        matchExtensionMinutes: 5,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 1, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 2, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `in-progress`,
+                bestOf: 3,
+                currentGameNumber: 2,
+                leftWins: 1,
+                rightWins: 0,
+                gameIds: [`game-1`],
+                sessionId: `session-2`,
+                startedAt: now - 10 * 60_000,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+        extensionRequests: [
+            {
+                id: `extension-g1-approved`,
+                matchId: `match-winners-1-1`,
+                gameNumber: 1,
+                requestedByProfileId: `player-2`,
+                requestedByDisplayName: `Player 2`,
+                requestedAt: now - 60_000,
+                status: `approved`,
+                resolvedByProfileId: `organizer-1`,
+                resolvedAt: now - 10_000,
+            },
+        ],
+    });
+    const { service, sessionManager } = createService(tournament);
+    sessionManager.sessions.set(`session-2`, {
+        id: `session-2`,
+        players: [
+            { id: `session-2-player-1`, profileId: `player-1`, connection: { status: `connected` } },
+            { id: `session-2-player-2`, profileId: `player-2`, connection: { status: `disconnected` } },
+        ],
+        state: { status: `lobby` },
+        tournament: null,
+    });
+
+    const claim = await service.claimWin(tournament.id, `match-winners-1-1`, user);
+    assert.equal(claim.matchId, `match-winners-1-1`);
+    assert.equal(claim.gameNumber, 2);
+    assert.ok(claim.expiresAt > claim.startedAt);
+
+    (service as unknown as {
+        cancelClaimWin: (matchId: string, sessionId: string) => void;
+    }).cancelClaimWin(`match-winners-1-1`, `session-2`);
+});

--- a/packages/backend/src/tournament/tournamentService.test.ts
+++ b/packages/backend/src/tournament/tournamentService.test.ts
@@ -730,6 +730,228 @@ test(`getTournamentDetail refreshes double-elimination participant statuses when
     assert.equal(runnerUp?.status, `eliminated`);
 });
 
+test(`roundDelayMinutes keeps the grand final pending until its cooldown expires`, async () => {
+    const now = Date.now();
+    const tournament = createTournament({
+        status: `live`,
+        format: `double-elimination`,
+        roundDelayMinutes: 10,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 11, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 12, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-2-1`,
+                bracket: `winners`,
+                round: 2,
+                order: 1,
+                state: `completed`,
+                winnerProfileId: `player-1`,
+                loserProfileId: `player-2`,
+                resolvedAt: now - 60_000,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+            createMatch({
+                id: `match-losers-2-1`,
+                bracket: `losers`,
+                round: 2,
+                order: 1,
+                state: `completed`,
+                winnerProfileId: `player-2`,
+                loserProfileId: `player-1`,
+                resolvedAt: now - 60_000,
+                slots: [
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                ],
+            }),
+            createMatch({
+                id: `match-grand-final-1-1`,
+                bracket: `grand-final`,
+                round: 1,
+                order: 1,
+                state: `pending`,
+                slots: [
+                    createSlot({ source: { type: `winner`, matchId: `match-winners-2-1` } }),
+                    createSlot({ source: { type: `winner`, matchId: `match-losers-2-1` } }),
+                ],
+            }),
+        ],
+    });
+    const { service } = createService(tournament);
+
+    const detail = await service.getTournamentDetail(tournament.id, null);
+    const grandFinal = detail?.matches.find((match) => match.id === `match-grand-final-1-1`);
+
+    assert.equal(grandFinal?.state, `pending`);
+    assert.equal(grandFinal?.sessionId, null);
+    assert.equal(grandFinal?.slots[0].profileId, `player-1`);
+    assert.equal(grandFinal?.slots[1].profileId, `player-2`);
+});
+
+test(`roundDelayMinutes keeps the grand-final reset pending until its cooldown expires`, async () => {
+    const now = Date.now();
+    const tournament = createTournament({
+        status: `live`,
+        format: `double-elimination`,
+        roundDelayMinutes: 10,
+        seriesSettings: {
+            earlyRoundsBestOf: 1,
+            finalsBestOf: 1,
+            grandFinalBestOf: 1,
+            grandFinalResetEnabled: true,
+        },
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 11, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 12, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-grand-final-1-1`,
+                bracket: `grand-final`,
+                round: 1,
+                order: 1,
+                state: `completed`,
+                winnerProfileId: `player-2`,
+                loserProfileId: `player-1`,
+                resolvedAt: now - 60_000,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+            createMatch({
+                id: `match-grand-final-reset-1-1`,
+                bracket: `grand-final-reset`,
+                round: 1,
+                order: 1,
+                state: `pending`,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+    });
+    const { service } = createService(tournament);
+
+    const detail = await service.getTournamentDetail(tournament.id, null);
+    const grandFinalReset = detail?.matches.find((match) => match.id === `match-grand-final-reset-1-1`);
+
+    assert.equal(detail?.status, `live`);
+    assert.equal(grandFinalReset?.state, `pending`);
+    assert.equal(grandFinalReset?.sessionId, null);
+});
+
+test(`grand-final reset creation respects roundDelayMinutes in the production flow`, async () => {
+    const organizer = createAccountUser({ id: `organizer-1`, username: `Organizer` });
+    const tournament = createTournament({
+        status: `live`,
+        format: `double-elimination`,
+        roundDelayMinutes: 10,
+        seriesSettings: {
+            earlyRoundsBestOf: 1,
+            finalsBestOf: 1,
+            grandFinalBestOf: 1,
+            grandFinalResetEnabled: true,
+        },
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 11, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 12, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-grand-final-1-1`,
+                bracket: `grand-final`,
+                round: 1,
+                order: 1,
+                state: `ready`,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1, source: { type: `winner`, matchId: `match-winners-2-1` } }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2, source: { type: `winner`, matchId: `match-losers-2-1` } }),
+                ],
+            }),
+        ],
+    });
+    const { service } = createService(tournament);
+
+    const detail = await service.awardWalkover(tournament.id, `match-grand-final-1-1`, `player-2`, organizer);
+    const grandFinalReset = detail.matches.find((match) => match.bracket === `grand-final-reset`);
+
+    assert.equal(detail.status, `live`);
+    assert.equal(grandFinalReset?.state, `pending`);
+    assert.equal(grandFinalReset?.sessionId, null);
+});
+
+test(`even losers rounds wait for both prerequisite matches before becoming ready`, async () => {
+    const now = Date.now();
+    const tournament = createTournament({
+        status: `live`,
+        format: `double-elimination`,
+        roundDelayMinutes: 10,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 11, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 12, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+            createParticipant({ profileId: `player-3`, displayName: `Player 3`, registeredAt: 3, checkedInAt: 13, status: `checked-in`, checkInState: `checked-in`, seed: 3 }),
+            createParticipant({ profileId: `player-4`, displayName: `Player 4`, registeredAt: 4, checkedInAt: 14, status: `checked-in`, checkInState: `checked-in`, seed: 4 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-losers-1-1`,
+                bracket: `losers`,
+                round: 1,
+                order: 1,
+                state: `completed`,
+                winnerProfileId: `player-3`,
+                loserProfileId: `player-4`,
+                resolvedAt: now - 20 * 60_000,
+                slots: [
+                    createSlot({ profileId: `player-3`, displayName: `Player 3`, seed: 3 }),
+                    createSlot({ profileId: `player-4`, displayName: `Player 4`, seed: 4 }),
+                ],
+            }),
+            createMatch({
+                id: `match-winners-2-1`,
+                bracket: `winners`,
+                round: 2,
+                order: 1,
+                state: `completed`,
+                winnerProfileId: `player-1`,
+                loserProfileId: `player-2`,
+                resolvedAt: now - 60_000,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+            createMatch({
+                id: `match-losers-2-1`,
+                bracket: `losers`,
+                round: 2,
+                order: 1,
+                state: `pending`,
+                slots: [
+                    createSlot({ source: { type: `winner`, matchId: `match-losers-1-1` } }),
+                    createSlot({ source: { type: `loser`, matchId: `match-winners-2-1` } }),
+                ],
+            }),
+        ],
+    });
+    const { service } = createService(tournament);
+
+    const detail = await service.getTournamentDetail(tournament.id, null);
+    const losersRoundTwo = detail?.matches.find((match) => match.id === `match-losers-2-1`);
+
+    assert.equal(losersRoundTwo?.state, `pending`);
+    assert.equal(losersRoundTwo?.sessionId, null);
+    assert.equal(losersRoundTwo?.slots[0].profileId, `player-3`);
+    assert.equal(losersRoundTwo?.slots[1].profileId, `player-2`);
+});
+
 test(`reconcileAllTournaments only records one timeout warning per timeout window`, async () => {
     const matchStartedAt = Date.now() - 10 * 60_000;
     const tournament = createTournament({

--- a/packages/backend/src/tournament/tournamentService.test.ts
+++ b/packages/backend/src/tournament/tournamentService.test.ts
@@ -160,13 +160,28 @@ class FakeTournamentRepository {
         return [...this.tournaments.values()]
             .filter((tournament) =>
                 tournament.createdByProfileId === userId
-                || tournament.participants.some((participant) => participant.profileId === userId))
+                || tournament.participants.some((participant) => participant.profileId === userId)
+                || tournament.organizers.includes(userId)
+                || tournament.subscriberProfileIds.includes(userId))
             .map((tournament) => structuredClone(tournament));
     }
 
-    async listPastTournaments(_userId: string | null, _page: number, limit: number): Promise<{ tournaments: TournamentRecord[]; total: number }> {
+    async listPastTournaments(userId: string | null, _page: number, limit: number): Promise<{ tournaments: TournamentRecord[]; total: number }> {
         const tournaments = [...this.tournaments.values()]
-            .filter((tournament) => tournament.status === `completed` || tournament.status === `cancelled`)
+            .filter((tournament) =>
+                (tournament.status === `completed` || tournament.status === `cancelled`)
+                && (
+                    tournament.isPublished
+                    || (
+                        userId !== null
+                        && (
+                            tournament.createdByProfileId === userId
+                            || tournament.participants.some((participant) => participant.profileId === userId)
+                            || tournament.organizers.includes(userId)
+                            || tournament.subscriberProfileIds.includes(userId)
+                        )
+                    )
+                ))
             .sort((left, right) => (right.completedAt ?? right.updatedAt) - (left.completedAt ?? left.updatedAt));
         return {
             tournaments: tournaments.slice(0, limit).map((tournament) => structuredClone(tournament)),
@@ -212,6 +227,32 @@ class DelayedDetailSaveTournamentRepository extends FakeTournamentRepository {
     override async saveTournament(tournament: TournamentRecord): Promise<void> {
         const timedOutMatch = tournament.matches.find((match) => match.id === `match-swiss-1-1`);
         if (timedOutMatch?.state === `in-progress`) {
+            this.staleSaveStartedResolver?.();
+            await this.releaseStaleSave;
+        }
+
+        await super.saveTournament(tournament);
+    }
+}
+
+class DelayedUnsubscribeSaveTournamentRepository extends FakeTournamentRepository {
+    private staleSaveStartedResolver: (() => void) | null = null;
+    private releaseStaleSaveResolver: (() => void) | null = null;
+    readonly staleSaveStarted = new Promise<void>((resolve) => {
+        this.staleSaveStartedResolver = resolve;
+    });
+    private readonly releaseStaleSave = new Promise<void>((resolve) => {
+        this.releaseStaleSaveResolver = resolve;
+    });
+
+    allowStaleSave(): void {
+        this.releaseStaleSaveResolver?.();
+    }
+
+    override async saveTournament(tournament: TournamentRecord): Promise<void> {
+        const isUnsubscribeMutation = tournament.organizers.length === 0
+            && tournament.matches.some((match) => match.state === `in-progress`);
+        if (isUnsubscribeMutation) {
             this.staleSaveStartedResolver?.();
             await this.releaseStaleSave;
         }
@@ -361,6 +402,7 @@ test(`registerCurrentUser reuses a dropped participant record instead of creatin
     const user = createAccountUser({ id: `player-1`, username: `Player One` });
     const tournament = createTournament({
         status: `registration-open`,
+        checkInOpensAt: Date.now() + 60_000,
         participants: [
             createParticipant({
                 profileId: user.id,
@@ -655,13 +697,116 @@ test(`waitlist check-in rejects attempts after the waitlist window closes`, asyn
 
     await assert.rejects(
         () => service.checkInCurrentUser(tournament.id, player),
-        /Waitlist check-in has closed/,
+        /Check-in is not open/,
     );
 
     const stored = repository.getSync(tournament.id);
     const waitlistedParticipant = stored.participants.find((participant) => participant.profileId === player.id);
-    assert.equal(waitlistedParticipant?.status, `waitlisted`);
+    assert.equal(stored.status, `cancelled`);
+    assert.equal(waitlistedParticipant?.status, `dropped`);
     assert.equal(waitlistedParticipant?.checkedInAt, null);
+});
+
+test(`swiss pairings keep players within their score groups when a same-record pairing is available`, async () => {
+    const tournament = createTournament({
+        status: `live`,
+        format: `swiss`,
+        maxPlayers: 4,
+        swissRoundCount: 3,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 11, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 12, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+            createParticipant({ profileId: `player-3`, displayName: `Player 3`, registeredAt: 3, checkedInAt: 13, status: `checked-in`, checkInState: `checked-in`, seed: 3 }),
+            createParticipant({ profileId: `player-4`, displayName: `Player 4`, registeredAt: 4, checkedInAt: 14, status: `checked-in`, checkInState: `checked-in`, seed: 4 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-swiss-1-1`,
+                bracket: `swiss`,
+                round: 1,
+                order: 1,
+                state: `completed`,
+                winnerProfileId: `player-1`,
+                loserProfileId: `player-2`,
+                resultType: `played`,
+                resolvedAt: 100,
+                gameIds: [`game-1`],
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+            createMatch({
+                id: `match-swiss-1-2`,
+                bracket: `swiss`,
+                round: 1,
+                order: 2,
+                state: `completed`,
+                winnerProfileId: `player-4`,
+                loserProfileId: `player-3`,
+                resultType: `played`,
+                resolvedAt: 101,
+                gameIds: [`game-2`],
+                slots: [
+                    createSlot({ profileId: `player-3`, displayName: `Player 3`, seed: 3 }),
+                    createSlot({ profileId: `player-4`, displayName: `Player 4`, seed: 4 }),
+                ],
+            }),
+        ],
+    });
+    const { service, repository } = createService(tournament);
+
+    await service.reconcileAllTournaments();
+
+    const roundTwoMatches = repository.getSync(tournament.id).matches
+        .filter((match) => match.bracket === `swiss` && match.round === 2)
+        .sort((left, right) => left.order - right.order)
+        .map((match) => match.slots.map((slot) => slot.profileId));
+
+    assert.deepEqual(roundTwoMatches, [
+        [`player-1`, `player-4`],
+        [`player-2`, `player-3`],
+    ]);
+});
+
+test(`getTournamentDetail eagerly advances stale pre-start tournaments`, async () => {
+    const tournament = createTournament({
+        status: `registration-open`,
+        scheduledStartAt: Date.now() + 60_000,
+        checkInOpensAt: Date.now() - 1_000,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, status: `registered`, checkInState: `not-open` }),
+        ],
+    });
+    const { service, repository } = createService(tournament);
+
+    const detail = await service.getTournamentDetail(tournament.id, null);
+    const stored = repository.getSync(tournament.id);
+
+    assert.equal(detail?.status, `check-in-open`);
+    assert.equal(detail?.participants[0]?.checkInState, `pending`);
+    assert.equal(stored.status, `check-in-open`);
+});
+
+test(`checkInCurrentUser reconciles stale pre-start status before validating the request`, async () => {
+    const player = createAccountUser({ id: `player-1`, username: `Player 1` });
+    const tournament = createTournament({
+        status: `registration-open`,
+        scheduledStartAt: Date.now() + 60_000,
+        checkInOpensAt: Date.now() - 1_000,
+        participants: [
+            createParticipant({ profileId: player.id, displayName: player.username, registeredAt: 1, status: `registered`, checkInState: `not-open` }),
+        ],
+    });
+    const { service, repository } = createService(tournament);
+
+    const detail = await service.checkInCurrentUser(tournament.id, player);
+    const storedParticipant = repository.getSync(tournament.id).participants.find((participant) => participant.profileId === player.id);
+
+    assert.equal(detail.status, `check-in-open`);
+    assert.equal(detail.participants.find((participant) => participant.profileId === player.id)?.status, `checked-in`);
+    assert.equal(storedParticipant?.status, `checked-in`);
+    assert.notEqual(storedParticipant?.checkedInAt, null);
 });
 
 test(`viewer state hides register and waitlist actions for ineligible users`, async () => {
@@ -692,6 +837,32 @@ test(`viewer state hides register and waitlist actions for ineligible users`, as
 
     assert.equal(whitelistDetail?.viewer.canRegister, false);
     assert.equal(blacklistDetail?.viewer.canJoinWaitlist, false);
+});
+
+test(`private tournaments appear in listings for organizers`, async () => {
+    const organizer = createAccountUser({ id: `helper-organizer`, username: `Helper Organizer` });
+    const activeTournament = createTournament({
+        id: `tournament-active`,
+        visibility: `private`,
+        isPublished: false,
+        status: `registration-open`,
+        organizers: [organizer.id],
+    });
+    const completedTournament = createTournament({
+        id: `tournament-completed`,
+        visibility: `private`,
+        isPublished: false,
+        status: `completed`,
+        completedAt: 100,
+        organizers: [organizer.id],
+    });
+    const { service, repository } = createService(activeTournament);
+    repository.saveSync(completedTournament);
+
+    const listing = await service.listTournaments(organizer);
+
+    assert.deepEqual(listing.tournaments.map((tournament) => tournament.id), [activeTournament.id]);
+    assert.ok(listing.past.some((tournament) => tournament.id === completedTournament.id));
 });
 
 test(`getTournamentDetail refreshes double-elimination participant statuses when a live tournament completes during eager reconciliation`, async () => {
@@ -1363,6 +1534,53 @@ test(`getTournamentDetail does not overwrite a newer live tournament update`, as
     const stored = repository.getSync(tournament.id);
     const match = stored.matches.find((entry) => entry.id === `match-swiss-1-1`);
 
+    assert.equal(match?.state, `completed`);
+    assert.equal(match?.winnerProfileId, `player-1`);
+});
+
+test(`unsubscribeFromTournament does not overwrite newer live tournament updates`, async () => {
+    const creator = createAccountUser({ id: `organizer-1`, username: `Organizer` });
+    const helperOrganizer = createAccountUser({ id: `helper-organizer`, username: `Helper Organizer` });
+    const tournament = createTournament({
+        status: `live`,
+        format: `single-elimination`,
+        organizers: [helperOrganizer.id],
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 11, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 12, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `in-progress`,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+    });
+    const repository = new DelayedUnsubscribeSaveTournamentRepository(tournament);
+    const { service } = createServiceWithOverrides({ repository });
+
+    const unsubscribePromise = service.unsubscribeFromTournament(tournament.id, helperOrganizer);
+    await repository.staleSaveStarted;
+
+    const awardPromise = service.awardWalkover(tournament.id, `match-winners-1-1`, `player-1`, creator);
+
+    repository.allowStaleSave();
+    await Promise.all([
+        unsubscribePromise,
+        awardPromise,
+    ]);
+
+    const stored = repository.getSync(tournament.id);
+    const match = stored.matches.find((entry) => entry.id === `match-winners-1-1`);
+
+    assert.deepEqual(stored.organizers, []);
     assert.equal(match?.state, `completed`);
     assert.equal(match?.winnerProfileId, `player-1`);
 });

--- a/packages/backend/src/tournament/tournamentService.test.ts
+++ b/packages/backend/src/tournament/tournamentService.test.ts
@@ -197,6 +197,13 @@ class FakeTournamentRepository {
             .map((tournament) => structuredClone(tournament));
     }
 
+    async countActiveTournamentsForUser(userId: string): Promise<number> {
+        return [...this.tournaments.values()].filter((tournament) =>
+            tournament.createdByProfileId === userId
+            && tournament.status !== `completed`
+            && tournament.status !== `cancelled`).length;
+    }
+
     async countTournamentsCreatedByUser(userId: string): Promise<number> {
         return [...this.tournaments.values()].filter((tournament) => tournament.createdByProfileId === userId).length;
     }
@@ -309,6 +316,13 @@ class FakeSessionManager {
             Object.assign(session.tournament, update);
         }
     }
+
+    clearSessionTournamentInfo(sessionId: string) {
+        const session = this.sessions.get(sessionId);
+        if (session) {
+            session.tournament = null;
+        }
+    }
 }
 
 class FakeGameHistoryRepository {
@@ -318,6 +332,27 @@ class FakeGameHistoryRepository {
 
     async getFinishedGameBySessionId(): Promise<null> {
         return null;
+    }
+}
+
+class FakeAuthRepository {
+    readonly users = new Map<string, AccountUserProfile>();
+
+    constructor(initialUsers: AccountUserProfile[] = []) {
+        initialUsers.forEach((user) => {
+            this.users.set(user.id, user);
+        });
+    }
+
+    async getUserProfileById(profileId: string): Promise<AccountUserProfile | null> {
+        return this.users.get(profileId) ?? null;
+    }
+
+    async getUserProfilesByIds(profileIds: string[]): Promise<Map<string, AccountUserProfile>> {
+        return new Map(profileIds.flatMap((profileId) => {
+            const user = this.users.get(profileId);
+            return user ? [[profileId, user] as const] : [];
+        }));
     }
 }
 
@@ -358,15 +393,17 @@ function createService(initialTournament: TournamentRecord) {
     const repository = new FakeTournamentRepository(initialTournament);
     const sessionManager = new FakeSessionManager();
     const eventSink = new FakeTournamentEventSink();
+    const authRepository = new FakeAuthRepository();
     const service = new TournamentService(
         repository as never,
-        {} as never,
+        authRepository as never,
         sessionManager as never,
         new FakeGameHistoryRepository() as never,
     );
     service.setEventHandlers(eventSink);
 
     return {
+        authRepository,
         repository,
         sessionManager,
         eventSink,
@@ -378,19 +415,22 @@ function createServiceWithOverrides(options: {
     repository: FakeTournamentRepository;
     sessionManager?: FakeSessionManager;
     eventSink?: FakeTournamentEventSink;
+    authRepository?: FakeAuthRepository;
 }) {
     const repository = options.repository;
     const sessionManager = options.sessionManager ?? new FakeSessionManager();
     const eventSink = options.eventSink ?? new FakeTournamentEventSink();
+    const authRepository = options.authRepository ?? new FakeAuthRepository();
     const service = new TournamentService(
         repository as never,
-        {} as never,
+        authRepository as never,
         sessionManager as never,
         new FakeGameHistoryRepository() as never,
     );
     service.setEventHandlers(eventSink);
 
     return {
+        authRepository,
         repository,
         sessionManager,
         eventSink,
@@ -459,6 +499,64 @@ test(`awardWalkover rejects winners that are not assigned to the match`, async (
     const stored = repository.getSync(tournament.id);
     assert.equal(stored.matches[0]?.winnerProfileId, null);
     assert.equal(stored.matches[0]?.state, `ready`);
+});
+
+test(`awardWalkover clears the old session tournament context`, async () => {
+    const organizer = createAccountUser({ id: `organizer-1`, username: `Organizer` });
+    const tournament = createTournament({
+        status: `live`,
+        format: `single-elimination`,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, status: `checked-in`, checkedInAt: 1, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, status: `checked-in`, checkedInAt: 2, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `in-progress`,
+                sessionId: `session-award-walkover`,
+                startedAt: Date.now() - 60_000,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+    });
+    const { service, sessionManager } = createService(tournament);
+    sessionManager.sessions.set(`session-award-walkover`, {
+        id: `session-award-walkover`,
+        players: [
+            { id: `session-award-walkover-player-1`, profileId: `player-1`, connection: { status: `connected` } },
+            { id: `session-award-walkover-player-2`, profileId: `player-2`, connection: { status: `disconnected` } },
+        ],
+        state: { status: `lobby` },
+        tournament: {
+            tournamentId: tournament.id,
+            tournamentName: tournament.name,
+            matchId: `match-winners-1-1`,
+            bracket: `winners`,
+            round: 1,
+            order: 1,
+            bestOf: 1,
+            currentGameNumber: 1,
+            leftWins: 0,
+            rightWins: 0,
+            matchJoinTimeoutMs: tournament.matchJoinTimeoutMinutes * 60_000,
+            matchExtensionMs: (tournament.matchExtensionMinutes ?? tournament.matchJoinTimeoutMinutes) * 60_000,
+            pendingExtension: false,
+            matchStartedAt: Date.now() - 60_000,
+            leftDisplayName: `Player 1`,
+            rightDisplayName: `Player 2`,
+        },
+    });
+
+    await service.awardWalkover(tournament.id, `match-winners-1-1`, `player-1`, organizer);
+
+    assert.equal(sessionManager.sessions.get(`session-award-walkover`)?.tournament, null);
 });
 
 test(`reopenMatch rejects pending matches that do not have an active session to reopen`, async () => {
@@ -653,6 +751,51 @@ test(`swiss tournaments can start with two checked-in players`, async () => {
     assert.equal(detail.matches[0]?.bracket, `swiss`);
 });
 
+test(`createTournament preserves auto swiss round count until the tournament starts`, async () => {
+    const organizer = createAccountUser({ id: `organizer-1`, username: `Organizer` });
+    const { service } = createService(createTournament());
+
+    const detail = await service.createTournament(organizer, {
+        name: `Swiss Auto`,
+        description: `Auto rounds`,
+        format: `swiss`,
+        visibility: `private`,
+        scheduledStartAt: Date.now() + 60 * 60 * 1000,
+        checkInWindowMinutes: 30,
+        maxPlayers: 16,
+        timeControl: { mode: `unlimited` },
+        seriesSettings: {
+            earlyRoundsBestOf: 1,
+            finalsBestOf: 3,
+            grandFinalBestOf: 5,
+            grandFinalResetEnabled: true,
+        },
+    });
+
+    assert.equal(detail.swissRoundCount, null);
+});
+
+test(`auto swiss round count recalculates from checked-in entrants at start`, async () => {
+    const organizer = createAccountUser({ id: `organizer-1`, username: `Organizer` });
+    const tournament = createTournament({
+        status: `check-in-open`,
+        format: `swiss`,
+        maxPlayers: 16,
+        swissRoundCount: null,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 11, status: `checked-in`, checkInState: `checked-in` }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 12, status: `checked-in`, checkInState: `checked-in` }),
+            createParticipant({ profileId: `player-3`, displayName: `Player 3`, registeredAt: 3, checkedInAt: 13, status: `checked-in`, checkInState: `checked-in` }),
+            createParticipant({ profileId: `player-4`, displayName: `Player 4`, registeredAt: 4, checkedInAt: 14, status: `checked-in`, checkInState: `checked-in` }),
+        ],
+    });
+    const { service } = createService(tournament);
+
+    const detail = await service.startTournament(tournament.id, organizer);
+
+    assert.equal(detail.swissRoundCount, 2);
+});
+
 test(`waitlist timeout starts the tournament cleanly after replacement check-ins`, async () => {
     const tournament = createTournament({
         status: `waitlist-open`,
@@ -705,6 +848,29 @@ test(`waitlist check-in rejects attempts after the waitlist window closes`, asyn
     assert.equal(stored.status, `cancelled`);
     assert.equal(waitlistedParticipant?.status, `dropped`);
     assert.equal(waitlistedParticipant?.checkedInAt, null);
+});
+
+test(`updateTournament rejects reducing maxPlayers below the current field size`, async () => {
+    const organizer = createAccountUser({ id: `organizer-1`, username: `Organizer` });
+    const tournament = createTournament({
+        format: `double-elimination`,
+        maxPlayers: 8,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, status: `registered`, checkInState: `not-open` }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, status: `registered`, checkInState: `not-open` }),
+            createParticipant({ profileId: `player-3`, displayName: `Player 3`, registeredAt: 3, status: `registered`, checkInState: `not-open` }),
+            createParticipant({ profileId: `player-4`, displayName: `Player 4`, registeredAt: 4, status: `registered`, checkInState: `not-open` }),
+            createParticipant({ profileId: `player-5`, displayName: `Player 5`, registeredAt: 5, status: `registered`, checkInState: `not-open` }),
+        ],
+    });
+    const { service, repository } = createService(tournament);
+
+    await assert.rejects(
+        () => service.updateTournament(tournament.id, organizer, { maxPlayers: 4 }),
+        /Max players cannot be reduced below the current field size of 5/,
+    );
+
+    assert.equal(repository.getSync(tournament.id).maxPlayers, 8);
 });
 
 test(`swiss pairings keep players within their score groups when a same-record pairing is available`, async () => {
@@ -863,6 +1029,273 @@ test(`private tournaments appear in listings for organizers`, async () => {
 
     assert.deepEqual(listing.tournaments.map((tournament) => tournament.id), [activeTournament.id]);
     assert.ok(listing.past.some((tournament) => tournament.id === completedTournament.id));
+});
+
+test(`stale pending extensions expire so they do not freeze timed-out matches`, async () => {
+    const now = Date.now();
+    const tournament = createTournament({
+        status: `live`,
+        format: `single-elimination`,
+        matchJoinTimeoutMinutes: 5,
+        matchExtensionMinutes: 5,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 11, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 12, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `in-progress`,
+                sessionId: `session-extension-timeout`,
+                startedAt: now - 15 * 60_000,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+        extensionRequests: [
+            {
+                id: `extension-pending`,
+                matchId: `match-winners-1-1`,
+                gameNumber: 1,
+                requestedByProfileId: `player-2`,
+                requestedByDisplayName: `Player 2`,
+                requestedAt: now - 6 * 60_000,
+                status: `pending`,
+                resolvedByProfileId: null,
+                resolvedAt: null,
+            },
+        ],
+    });
+    const { service, repository, sessionManager } = createService(tournament);
+    sessionManager.sessions.set(`session-extension-timeout`, {
+        id: `session-extension-timeout`,
+        players: [
+            { id: `p1`, profileId: `player-1`, connection: { status: `connected` } },
+            { id: `p2`, profileId: `player-2`, connection: { status: `disconnected` } },
+        ],
+        state: { status: `lobby` },
+        tournament: null,
+    });
+
+    await service.reconcileAllTournaments();
+
+    const stored = repository.getSync(tournament.id);
+    const extension = stored.extensionRequests.find((request) => request.id === `extension-pending`);
+
+    assert.equal(extension?.status, `denied`);
+    assert.notEqual(extension?.resolvedAt, null);
+    assert.ok(stored.activity.some((entry) => entry.type === `extension-expired`));
+    assert.ok(stored.activity.some((entry) => entry.type === `timeout-warning`));
+});
+
+test(`cancelTournament clears active claim wins and prevents later claim resolution`, async () => {
+    const organizer = createAccountUser({ id: `organizer-1`, username: `Organizer` });
+    const player = createAccountUser({ id: `player-1`, username: `Player 1` });
+    const now = Date.now();
+    const tournament = createTournament({
+        status: `live`,
+        format: `single-elimination`,
+        matchJoinTimeoutMinutes: 5,
+        participants: [
+            createParticipant({ profileId: player.id, displayName: player.username, registeredAt: 1, checkedInAt: 11, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 12, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `in-progress`,
+                sessionId: `session-cancel-claim`,
+                startedAt: now - 10 * 60_000,
+                slots: [
+                    createSlot({ profileId: player.id, displayName: player.username, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+    });
+    const { service, repository, sessionManager, eventSink } = createService(tournament);
+    sessionManager.sessions.set(`session-cancel-claim`, {
+        id: `session-cancel-claim`,
+        players: [
+            { id: `p1`, profileId: player.id, connection: { status: `connected` } },
+            { id: `p2`, profileId: `player-2`, connection: { status: `disconnected` } },
+        ],
+        state: { status: `lobby` },
+        tournament: null,
+    });
+
+    await service.claimWin(tournament.id, `match-winners-1-1`, player);
+    await service.cancelTournament(tournament.id, organizer);
+    await (service as unknown as {
+        resolveClaimWin: (tournamentId: string, matchId: string) => Promise<void>;
+    }).resolveClaimWin(tournament.id, `match-winners-1-1`);
+
+    const stored = repository.getSync(tournament.id);
+    const match = stored.matches.find((entry) => entry.id === `match-winners-1-1`);
+
+    assert.equal(service.getActiveClaimWin(`match-winners-1-1`), null);
+    assert.equal(stored.status, `cancelled`);
+    assert.equal(match?.state, `in-progress`);
+    assert.equal(match?.winnerProfileId, null);
+    assert.deepEqual(eventSink.sessionClaimWins.at(-1), {
+        sessionId: `session-cancel-claim`,
+        state: null,
+    });
+});
+
+test(`cancelled tournaments reject organizer match actions`, async () => {
+    const organizer = createAccountUser({ id: `organizer-1`, username: `Organizer` });
+    const tournament = createTournament({
+        status: `cancelled`,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 1, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 2, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `in-progress`,
+                sessionId: `session-cancelled-match`,
+                startedAt: Date.now() - 60_000,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+    });
+    const { service } = createService(tournament);
+
+    await assert.rejects(
+        () => service.awardWalkover(tournament.id, `match-winners-1-1`, `player-1`, organizer),
+        /Matches can only be managed while the tournament is live/,
+    );
+    await assert.rejects(
+        () => service.reopenMatch(tournament.id, `match-winners-1-1`, organizer),
+        /Matches can only be managed while the tournament is live/,
+    );
+});
+
+test(`cancelTournament clears session tournament context and pending extensions`, async () => {
+    const organizer = createAccountUser({ id: `organizer-1`, username: `Organizer` });
+    const now = Date.now();
+    const tournament = createTournament({
+        status: `live`,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 1, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 2, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `in-progress`,
+                sessionId: `session-cancelled-context`,
+                startedAt: now - 60_000,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+        extensionRequests: [
+            {
+                id: `extension-cancelled`,
+                matchId: `match-winners-1-1`,
+                gameNumber: 1,
+                requestedByProfileId: `player-1`,
+                requestedByDisplayName: `Player 1`,
+                requestedAt: now - 30_000,
+                status: `pending`,
+                resolvedByProfileId: null,
+                resolvedAt: null,
+            },
+        ],
+    });
+    const { service, repository, sessionManager } = createService(tournament);
+    sessionManager.sessions.set(`session-cancelled-context`, {
+        id: `session-cancelled-context`,
+        players: [
+            { id: `session-cancelled-context-player-1`, profileId: `player-1`, connection: { status: `connected` } },
+            { id: `session-cancelled-context-player-2`, profileId: `player-2`, connection: { status: `disconnected` } },
+        ],
+        state: { status: `lobby` },
+        tournament: {
+            tournamentId: tournament.id,
+            tournamentName: tournament.name,
+            matchId: `match-winners-1-1`,
+            bracket: `winners`,
+            round: 1,
+            order: 1,
+            bestOf: 1,
+            currentGameNumber: 1,
+            leftWins: 0,
+            rightWins: 0,
+            matchJoinTimeoutMs: tournament.matchJoinTimeoutMinutes * 60_000,
+            matchExtensionMs: (tournament.matchExtensionMinutes ?? tournament.matchJoinTimeoutMinutes) * 60_000,
+            pendingExtension: true,
+            matchStartedAt: now - 60_000,
+            leftDisplayName: `Player 1`,
+            rightDisplayName: `Player 2`,
+        },
+    });
+
+    await service.cancelTournament(tournament.id, organizer);
+
+    const stored = repository.getSync(tournament.id);
+    const extension = stored.extensionRequests.find((entry) => entry.id === `extension-cancelled`);
+    assert.equal(stored.status, `cancelled`);
+    assert.equal(extension?.status, `denied`);
+    assert.equal(sessionManager.sessions.get(`session-cancelled-context`)?.tournament, null);
+});
+
+test(`cancelled tournaments appear in the past tournament listing`, async () => {
+    const viewer = createAccountUser({ id: `viewer-1`, username: `Viewer` });
+    const cancelledTournament = createTournament({
+        id: `tournament-cancelled`,
+        visibility: `private`,
+        isPublished: false,
+        status: `cancelled`,
+        cancelledAt: 200,
+        organizers: [viewer.id],
+    });
+    const { service } = createService(cancelledTournament);
+
+    const listing = await service.listTournaments(viewer);
+
+    assert.equal(listing.tournaments.some((tournament) => tournament.id === cancelledTournament.id), false);
+    assert.ok(listing.past.some((tournament) => tournament.id === cancelledTournament.id));
+});
+
+test(`ownership transfer updates the creator display name`, async () => {
+    const creator = createAccountUser({ id: `organizer-1`, username: `Creator` });
+    const nextOwner = createAccountUser({ id: `organizer-2`, username: `Next Owner` });
+    const tournament = createTournament({
+        organizers: [nextOwner.id],
+        createdByProfileId: creator.id,
+        createdByDisplayName: creator.username,
+    });
+    const { service, repository, authRepository } = createService(tournament);
+    authRepository.users.set(nextOwner.id, nextOwner);
+
+    await service.unsubscribeFromTournament(tournament.id, creator, nextOwner.id);
+
+    const stored = repository.getSync(tournament.id);
+    assert.equal(stored.createdByProfileId, nextOwner.id);
+    assert.equal(stored.createdByDisplayName, nextOwner.username);
 });
 
 test(`getTournamentDetail refreshes double-elimination participant statuses when a live tournament completes during eager reconciliation`, async () => {
@@ -1307,6 +1740,7 @@ test(`best-of follow-up games reset startedAt and the session tournament timer`,
 
 test(`requestExtension is scoped to the current best-of game`, async () => {
     const user = createAccountUser({ id: `player-1`, username: `Player 1` });
+    const now = Date.now();
     const tournament = createTournament({
         status: `live`,
         format: `single-elimination`,
@@ -1320,12 +1754,14 @@ test(`requestExtension is scoped to the current best-of game`, async () => {
                 bracket: `winners`,
                 round: 1,
                 order: 1,
-                state: `ready`,
+                state: `in-progress`,
                 bestOf: 3,
                 currentGameNumber: 2,
                 leftWins: 1,
                 rightWins: 0,
                 gameIds: [`game-1`],
+                sessionId: `session-extension-scope`,
+                startedAt: now - 60_000,
                 slots: [
                     createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
                     createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
@@ -1346,7 +1782,33 @@ test(`requestExtension is scoped to the current best-of game`, async () => {
             },
         ],
     });
-    const { service } = createService(tournament);
+    const { service, sessionManager } = createService(tournament);
+    sessionManager.sessions.set(`session-extension-scope`, {
+        id: `session-extension-scope`,
+        players: [
+            { id: `session-extension-scope-player-1`, profileId: `player-1`, connection: { status: `connected` } },
+            { id: `session-extension-scope-player-2`, profileId: `player-2`, connection: { status: `disconnected` } },
+        ],
+        state: { status: `lobby` },
+        tournament: {
+            tournamentId: tournament.id,
+            tournamentName: tournament.name,
+            matchId: `match-winners-1-1`,
+            bracket: `winners`,
+            round: 1,
+            order: 1,
+            bestOf: 3,
+            currentGameNumber: 2,
+            leftWins: 1,
+            rightWins: 0,
+            matchJoinTimeoutMs: tournament.matchJoinTimeoutMinutes * 60_000,
+            matchExtensionMs: (tournament.matchExtensionMinutes ?? tournament.matchJoinTimeoutMinutes) * 60_000,
+            pendingExtension: false,
+            matchStartedAt: now - 60_000,
+            leftDisplayName: `Player 1`,
+            rightDisplayName: `Player 2`,
+        },
+    });
 
     const detail = await service.requestExtension(tournament.id, `match-winners-1-1`, user);
     const currentGameExtensions = detail.extensionRequests.filter((request) =>
@@ -1354,6 +1816,37 @@ test(`requestExtension is scoped to the current best-of game`, async () => {
 
     assert.equal(currentGameExtensions.length, 1);
     assert.equal(currentGameExtensions[0]?.status, `pending`);
+});
+
+test(`requestExtension rejects ready matches before the join timer starts`, async () => {
+    const user = createAccountUser({ id: `player-1`, username: `Player 1` });
+    const tournament = createTournament({
+        status: `live`,
+        format: `single-elimination`,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 1, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 2, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `ready`,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+    });
+    const { service } = createService(tournament);
+
+    await assert.rejects(
+        () => service.requestExtension(tournament.id, `match-winners-1-1`, user),
+        /This match is not eligible for an extension/,
+    );
 });
 
 test(`claimWin ignores approved extensions from earlier best-of games`, async () => {
@@ -1423,6 +1916,85 @@ test(`claimWin ignores approved extensions from earlier best-of games`, async ()
     }).cancelClaimWin(`match-winners-1-1`, `session-2`);
 });
 
+test(`resolveExtension rejects expired requests and clears the session pending state`, async () => {
+    const organizer = createAccountUser({ id: `organizer-1`, username: `Organizer` });
+    const now = Date.now();
+    const tournament = createTournament({
+        status: `live`,
+        format: `single-elimination`,
+        matchExtensionMinutes: 5,
+        participants: [
+            createParticipant({ profileId: `player-1`, displayName: `Player 1`, registeredAt: 1, checkedInAt: 1, status: `checked-in`, checkInState: `checked-in`, seed: 1 }),
+            createParticipant({ profileId: `player-2`, displayName: `Player 2`, registeredAt: 2, checkedInAt: 2, status: `checked-in`, checkInState: `checked-in`, seed: 2 }),
+        ],
+        matches: [
+            createMatch({
+                id: `match-winners-1-1`,
+                bracket: `winners`,
+                round: 1,
+                order: 1,
+                state: `in-progress`,
+                sessionId: `session-expired-extension`,
+                startedAt: now - 10 * 60_000,
+                slots: [
+                    createSlot({ profileId: `player-1`, displayName: `Player 1`, seed: 1 }),
+                    createSlot({ profileId: `player-2`, displayName: `Player 2`, seed: 2 }),
+                ],
+            }),
+        ],
+        extensionRequests: [
+            {
+                id: `extension-expired-resolution`,
+                matchId: `match-winners-1-1`,
+                gameNumber: 1,
+                requestedByProfileId: `player-1`,
+                requestedByDisplayName: `Player 1`,
+                requestedAt: now - 6 * 60_000,
+                status: `pending`,
+                resolvedByProfileId: null,
+                resolvedAt: null,
+            },
+        ],
+    });
+    const { service, repository, sessionManager } = createService(tournament);
+    sessionManager.sessions.set(`session-expired-extension`, {
+        id: `session-expired-extension`,
+        players: [
+            { id: `session-expired-extension-player-1`, profileId: `player-1`, connection: { status: `connected` } },
+            { id: `session-expired-extension-player-2`, profileId: `player-2`, connection: { status: `disconnected` } },
+        ],
+        state: { status: `lobby` },
+        tournament: {
+            tournamentId: tournament.id,
+            tournamentName: tournament.name,
+            matchId: `match-winners-1-1`,
+            bracket: `winners`,
+            round: 1,
+            order: 1,
+            bestOf: 1,
+            currentGameNumber: 1,
+            leftWins: 0,
+            rightWins: 0,
+            matchJoinTimeoutMs: tournament.matchJoinTimeoutMinutes * 60_000,
+            matchExtensionMs: (tournament.matchExtensionMinutes ?? tournament.matchJoinTimeoutMinutes) * 60_000,
+            pendingExtension: true,
+            matchStartedAt: now - 10 * 60_000,
+            leftDisplayName: `Player 1`,
+            rightDisplayName: `Player 2`,
+        },
+    });
+
+    await assert.rejects(
+        () => service.resolveExtension(tournament.id, `extension-expired-resolution`, true, organizer),
+        /This extension request has expired/,
+    );
+
+    const stored = repository.getSync(tournament.id);
+    const extension = stored.extensionRequests.find((entry) => entry.id === `extension-expired-resolution`);
+    assert.equal(extension?.status, `denied`);
+    assert.equal((sessionManager.sessions.get(`session-expired-extension`)?.tournament as { pendingExtension?: boolean } | null)?.pendingExtension, false);
+});
+
 test(`resolveClaimWin clears the session claim state after awarding the walkover`, async () => {
     const user = createAccountUser({ id: `player-1`, username: `Player 1` });
     const now = Date.now();
@@ -1458,7 +2030,24 @@ test(`resolveClaimWin clears the session claim state after awarding the walkover
             { id: `session-claim-player-2`, profileId: `player-2`, connection: { status: `disconnected` } },
         ],
         state: { status: `lobby` },
-        tournament: null,
+        tournament: {
+            tournamentId: tournament.id,
+            tournamentName: tournament.name,
+            matchId: `match-winners-1-1`,
+            bracket: `winners`,
+            round: 1,
+            order: 1,
+            bestOf: 1,
+            currentGameNumber: 1,
+            leftWins: 0,
+            rightWins: 0,
+            matchJoinTimeoutMs: tournament.matchJoinTimeoutMinutes * 60_000,
+            matchExtensionMs: (tournament.matchExtensionMinutes ?? tournament.matchJoinTimeoutMinutes) * 60_000,
+            pendingExtension: false,
+            matchStartedAt: now - 10 * 60_000,
+            leftDisplayName: user.username,
+            rightDisplayName: `Player 2`,
+        },
     });
 
     await service.claimWin(tournament.id, `match-winners-1-1`, user);
@@ -1476,6 +2065,7 @@ test(`resolveClaimWin clears the session claim state after awarding the walkover
         sessionId: `session-claim`,
         state: null,
     });
+    assert.equal(sessionManager.sessions.get(`session-claim`)?.tournament, null);
 });
 
 test(`getTournamentDetail does not overwrite a newer live tournament update`, async () => {

--- a/packages/backend/src/tournament/tournamentService.ts
+++ b/packages/backend/src/tournament/tournamentService.ts
@@ -370,19 +370,25 @@ function describeTournamentMatch(match: TournamentMatch): string {
     }
 }
 
-function getTournamentStandings(tournament: TournamentRecord): TournamentStanding[] {
-    if (tournament.format === `swiss`) {
-        return calculateSwissStandings(
-            tournament.participants.filter((participant) => participant.status !== `removed`),
-            tournament.matches,
-        );
-    }
-
-    return calculateEliminationStandings(tournament);
+function isPreStartLeaver(p: TournamentParticipant, tournament: TournamentRecord): boolean {
+    if (p.removedAt === null) return false;
+    if (tournament.startedAt === null) return true;
+    return p.removedAt < tournament.startedAt;
 }
 
-function calculateEliminationStandings(tournament: TournamentRecord): TournamentStanding[] {
-    const activeParticipants = tournament.participants.filter((p) => p.status !== `removed`);
+function getTournamentStandings(tournament: TournamentRecord): TournamentStanding[] {
+    const standingsParticipants = tournament.participants.filter(
+        (p) => p.status !== `removed` && !isPreStartLeaver(p, tournament),
+    );
+
+    if (tournament.format === `swiss`) {
+        return calculateSwissStandings(standingsParticipants, tournament.matches);
+    }
+
+    return calculateEliminationStandings(tournament, standingsParticipants);
+}
+
+function calculateEliminationStandings(tournament: TournamentRecord, activeParticipants = tournament.participants.filter((p) => p.status !== `removed`)): TournamentStanding[] {
 
     // Count wins/losses per player
     const winsByProfile = new Map<string, number>();

--- a/packages/backend/src/tournament/tournamentService.ts
+++ b/packages/backend/src/tournament/tournamentService.ts
@@ -947,6 +947,10 @@ export class TournamentService {
 
             // Waitlist check-in: waitlisted player claiming a freed slot
             if (tournament.status === `waitlist-open`) {
+                if (Date.now() >= (tournament.waitlistClosesAt ?? 0)) {
+                    throw new SessionError(`Waitlist check-in has closed for this tournament.`);
+                }
+
                 const waitlistedParticipant = tournament.participants.find((p) => p.profileId === user.id && p.status === `waitlisted`);
                 if (!waitlistedParticipant) {
                     throw new SessionError(`You are not on the waitlist for this tournament.`);
@@ -1576,6 +1580,9 @@ export class TournamentService {
             }
 
             if (countCheckedInParticipants(tournament) >= getMinimumParticipantsToStart(tournament.format)) {
+                tournament.status = `check-in-open`;
+                tournament.waitlistOpensAt = null;
+                tournament.waitlistClosesAt = null;
                 tournament.activity.unshift(createTournamentActivity(null, `waitlist-closed`, `Waitlist check-in closed.`));
                 await this.startTournamentRecord(tournament, null);
                 changed = true;

--- a/packages/backend/src/tournament/tournamentService.ts
+++ b/packages/backend/src/tournament/tournamentService.ts
@@ -323,6 +323,23 @@ function getMatchExtensionMinutes(tournament: TournamentRecord): number {
     return tournament.matchExtensionMinutes ?? tournament.matchJoinTimeoutMinutes;
 }
 
+function describeTournamentMatch(match: TournamentMatch): string {
+    switch (match.bracket) {
+        case `winners`:
+            return `Winners R${match.round} M${match.order}`;
+        case `losers`:
+            return `Losers R${match.round} M${match.order}`;
+        case `grand-final`:
+            return `Grand Final`;
+        case `grand-final-reset`:
+            return `Grand Final Reset`;
+        case `third-place`:
+            return `Third-Place Match`;
+        case `swiss`:
+            return `Swiss R${match.round} M${match.order}`;
+    }
+}
+
 function getTournamentStandings(tournament: TournamentRecord): TournamentStanding[] {
     if (tournament.format === `swiss`) {
         return calculateSwissStandings(
@@ -2514,29 +2531,7 @@ export class TournamentService {
     }
 
     private getPlayerFinalRank(tournament: TournamentRecord, userId: string): number | null {
-        if (tournament.format === `swiss`) {
-            const standings = calculateSwissStandings(
-                tournament.participants.filter((p) => p.status !== `removed`),
-                tournament.matches,
-            );
-            return standings.find((s) => s.profileId === userId)?.rank ?? null;
-        }
-
-        const completedMatches = tournament.matches
-            .filter((m) => m.state === `completed` && m.slots.some((s) => s.profileId === userId));
-        if (completedMatches.length === 0) return null;
-
-        const bracketOrder: Record<string, number> = { 'grand-final-reset': 4, 'grand-final': 3, 'winners': 2, 'losers': 1, 'swiss': 0 };
-        const lastMatch = completedMatches.sort((a, b) =>
-            (bracketOrder[b.bracket] ?? 0) - (bracketOrder[a.bracket] ?? 0) || b.round - a.round,
-        )[0]!;
-
-        if (lastMatch.winnerProfileId === userId) {
-            if (lastMatch.bracket === `grand-final` || lastMatch.bracket === `grand-final-reset`) return 1;
-            if (lastMatch.bracket === `winners` && lastMatch.round === Math.log2(tournament.maxPlayers)) return 1;
-        }
-        if (lastMatch.bracket === `grand-final` || lastMatch.bracket === `grand-final-reset`) return 2;
-        return null;
+        return getTournamentStandings(tournament).find((standing) => standing.profileId === userId)?.rank ?? null;
     }
 
     private computeUpcomingMatches(activeRecords: TournamentRecord[], userId: string): TournamentUpcomingMatch[] {
@@ -2631,7 +2626,7 @@ export class TournamentService {
             }
 
             // Already sent a warning for this match since the current timeout window started?
-            const timeoutWarningMessage = `Match ${match.order} in round ${match.round} timed out — waiting for player(s) to join.`;
+            const timeoutWarningMessage = `${describeTournamentMatch(match)} timed out — waiting for player(s) to join.`;
             const alreadyWarned = tournament.activity.some((activity) =>
                 activity.type === `timeout-warning`
                 && activity.message === timeoutWarningMessage

--- a/packages/backend/src/tournament/tournamentService.ts
+++ b/packages/backend/src/tournament/tournamentService.ts
@@ -134,14 +134,18 @@ function isExtensionForMatchGame(extension: TournamentExtensionRequest, matchId:
     return extension.matchId === matchId && getExtensionGameNumber(extension) === gameNumber;
 }
 
+function hasPendingExtensionForMatchGame(tournament: TournamentRecord, matchId: string, gameNumber: number): boolean {
+    return tournament.extensionRequests.some((extension) =>
+        isExtensionForMatchGame(extension, matchId, gameNumber) && extension.status === `pending`);
+}
+
 function normalizeDescription(value: string | null | undefined): string | null {
     const description = value?.trim() ?? ``;
     return description.length > 0 ? description : null;
 }
 
-function normalizeSwissRoundCount(
+function normalizeSwissRoundCountSetting(
     format: TournamentFormat,
-    maxPlayers: number,
     value: number | null | undefined,
 ): number | null {
     if (format !== `swiss`) {
@@ -152,7 +156,23 @@ function normalizeSwissRoundCount(
         return Math.max(1, Math.min(15, Math.floor(value)));
     }
 
-    return Math.max(1, Math.ceil(Math.log2(maxPlayers)));
+    return null;
+}
+
+function resolveSwissRoundCount(
+    format: TournamentFormat,
+    entrantCount: number,
+    value: number | null | undefined,
+): number | null {
+    if (format !== `swiss`) {
+        return null;
+    }
+
+    if (typeof value === `number` && Number.isFinite(value)) {
+        return Math.max(1, Math.min(15, Math.floor(value)));
+    }
+
+    return Math.max(1, Math.ceil(Math.log2(Math.max(2, entrantCount))));
 }
 
 function createTournamentActivity(
@@ -718,9 +738,14 @@ export class TournamentService {
 
             const nextFormat = update.format ?? tournament.format;
             const nextMaxPlayers = update.maxPlayers ?? tournament.maxPlayers;
+            const currentFieldSize = countRegisteredParticipants(tournament);
 
             if ((nextFormat === `single-elimination` || nextFormat === `double-elimination`) && !(TOURNAMENT_BRACKET_SIZES as readonly number[]).includes(nextMaxPlayers)) {
                 throw new SessionError(`Elimination formats require a bracket size of ${TOURNAMENT_BRACKET_SIZES.join(`, `)}.`);
+            }
+
+            if (nextMaxPlayers < currentFieldSize) {
+                throw new SessionError(`Max players cannot be reduced below the current field size of ${currentFieldSize}.`);
             }
 
             tournament.name = update.name ?? tournament.name;
@@ -732,7 +757,10 @@ export class TournamentService {
             tournament.checkInOpensAt = Math.max(0, tournament.scheduledStartAt - tournament.checkInWindowMinutes * 60_000);
             tournament.checkInClosesAt = tournament.scheduledStartAt;
             tournament.maxPlayers = nextMaxPlayers;
-            tournament.swissRoundCount = normalizeSwissRoundCount(nextFormat, nextMaxPlayers, update.swissRoundCount ?? tournament.swissRoundCount);
+            tournament.swissRoundCount = normalizeSwissRoundCountSetting(
+                nextFormat,
+                update.swissRoundCount === undefined ? tournament.swissRoundCount : update.swissRoundCount,
+            );
 
             if (update.timeControl) {
                 tournament.timeControl = { ...update.timeControl };
@@ -1195,6 +1223,9 @@ export class TournamentService {
         const tournament = await this.withTournamentLock(tournamentId, async () => {
             const tournament = await this.requireTournament(tournamentId);
             this.assertCanManageTournament(user, tournament);
+            if (tournament.status !== `live`) {
+                throw new SessionError(`Matches can only be managed while the tournament is live.`);
+            }
             const match = getMatchById(tournament, matchId);
             if (!(match.state === `ready` || match.state === `in-progress`)) {
                 throw new SessionError(`Only unresolved matches can be awarded.`);
@@ -1214,6 +1245,9 @@ export class TournamentService {
         const tournament = await this.withTournamentLock(tournamentId, async () => {
             const tournament = await this.requireTournament(tournamentId);
             this.assertCanManageTournament(user, tournament);
+            if (tournament.status !== `live`) {
+                throw new SessionError(`Matches can only be managed while the tournament is live.`);
+            }
             const match = getMatchById(tournament, matchId);
 
             if (match.state === `completed` || match.state === `pending`) {
@@ -1241,10 +1275,17 @@ export class TournamentService {
                 throw new SessionError(`Completed tournaments cannot be cancelled.`);
             }
 
+            this.cancelActiveClaimsForTournament(tournament);
+            const now = Date.now();
+            const cancelledPendingExtensions = this.cancelPendingExtensionsForTournament(tournament, now);
             tournament.status = `cancelled`;
-            tournament.cancelledAt = Date.now();
-            tournament.updatedAt = Date.now();
+            tournament.cancelledAt = now;
+            tournament.updatedAt = now;
+            this.clearTournamentSessions(tournament);
             tournament.activity.unshift(createTournamentActivity(user, `tournament-cancelled`, `Cancelled the tournament.`));
+            if (cancelledPendingExtensions) {
+                tournament.activity.unshift(createTournamentActivity(null, `extensions-cancelled`, `Pending extension requests were cancelled.`));
+            }
             await this.tournamentRepository.saveTournament(tournament);
             return tournament;
         });
@@ -1275,7 +1316,14 @@ export class TournamentService {
                         throw new SessionError(`The selected user is not an organizer of this tournament.`);
                     }
 
+                    const nextOwnerParticipant = tournament.participants.find((participant) => participant.profileId === transferTo) ?? null;
+                    const nextOwnerProfile = nextOwnerParticipant
+                        ? null
+                        : await this.authRepository.getUserProfileById(transferTo);
                     tournament.createdByProfileId = transferTo;
+                    tournament.createdByDisplayName = nextOwnerParticipant?.displayName
+                        ?? nextOwnerProfile?.username
+                        ?? tournament.createdByDisplayName;
                     tournament.organizers = otherOrganizers.filter((id) => id !== transferTo);
                     tournament.updatedAt = Date.now();
                     tournament.activity.unshift(createTournamentActivity(
@@ -1374,7 +1422,7 @@ export class TournamentService {
         } else if (request.maxPlayers < 2) {
             throw new SessionError(`At least 2 players are required.`);
         }
-        const swissRoundCount = normalizeSwissRoundCount(format, request.maxPlayers, request.swissRoundCount);
+        const swissRoundCount = normalizeSwissRoundCountSetting(format, request.swissRoundCount);
 
         return {
             version: 1,
@@ -1467,10 +1515,10 @@ export class TournamentService {
             }
         }
 
-        tournament.swissRoundCount = normalizeSwissRoundCount(
+        tournament.swissRoundCount = resolveSwissRoundCount(
             tournament.format,
-            tournament.maxPlayers,
-            tournament.swissRoundCount ?? checkedInParticipants.length,
+            checkedInParticipants.length,
+            tournament.swissRoundCount,
         );
 
         if (tournament.format === `single-elimination` || tournament.format === `double-elimination`) {
@@ -1961,12 +2009,7 @@ export class TournamentService {
                     const matchStartedAt = match.startedAt ?? Date.now();
                     match.state = `in-progress`;
                     match.startedAt = matchStartedAt;
-                    this.sessionManager.updateSessionTournamentInfo(match.sessionId, {
-                        currentGameNumber: match.currentGameNumber,
-                        leftWins: match.leftWins,
-                        rightWins: match.rightWins,
-                        matchStartedAt,
-                    });
+                    this.syncSessionTournamentInfo(tournament, match);
                     return true;
                 }
 
@@ -2110,12 +2153,17 @@ export class TournamentService {
         }
 
         const loserSlot = match.slots.find((slot) => slot.profileId !== winnerProfileId && !slot.isBye) ?? null;
+        const sessionId = match.sessionId;
         match.winnerProfileId = winnerProfileId;
         match.loserProfileId = loserSlot?.profileId ?? null;
         match.resultType = resultType;
         match.state = `completed`;
         match.resolvedAt = Date.now();
         match.sessionId = null;
+
+        if (sessionId && resultType !== `played`) {
+            this.clearSessionTournamentInfo(sessionId);
+        }
 
         if (match.bracket === `grand-final` && tournament.seriesSettings.grandFinalResetEnabled) {
             const winnersSlot = match.slots.find((slot) => slot.source?.type === `winner` && slot.source.matchId.includes(`winners`));
@@ -2437,10 +2485,34 @@ export class TournamentService {
             rightWins: match.rightWins,
             matchJoinTimeoutMs: tournament.matchJoinTimeoutMinutes * 60_000,
             matchExtensionMs: getMatchExtensionMinutes(tournament) * 60_000,
+            pendingExtension: hasPendingExtensionForMatchGame(tournament, match.id, match.currentGameNumber),
             matchStartedAt,
             leftDisplayName: match.slots[0].displayName,
             rightDisplayName: match.slots[1].displayName,
         };
+    }
+
+    private syncSessionTournamentInfo(tournament: TournamentRecord, match: TournamentMatch): void {
+        if (!match.sessionId) {
+            return;
+        }
+
+        this.sessionManager.updateSessionTournamentInfo(match.sessionId, this.toSessionTournamentInfo(tournament, match));
+        const sessionInfo = this.sessionManager.getSessionInfo(match.sessionId);
+        if (sessionInfo) {
+            this.emitSessionUpdated({
+                sessionId: match.sessionId as SessionInfo[`id`],
+                session: { tournament: sessionInfo.tournament },
+            });
+        }
+    }
+
+    private clearSessionTournamentInfo(sessionId: string): void {
+        this.sessionManager.clearSessionTournamentInfo(sessionId);
+        this.emitSessionUpdated({
+            sessionId: sessionId as SessionInfo[`id`],
+            session: { tournament: null },
+        });
     }
 
     private notifyMatchReady(tournament: TournamentRecord, match: TournamentMatch) {
@@ -2681,7 +2753,7 @@ export class TournamentService {
         const now = Date.now();
         const timeoutMs = tournament.matchJoinTimeoutMinutes * 60_000;
         const extensionMs = getMatchExtensionMinutes(tournament) * 60_000;
-        let changed = false;
+        let changed = this.expireStalePendingExtensions(tournament, now);
 
         for (const match of tournament.matches) {
             if (match.state !== `in-progress` || !match.startedAt || !match.sessionId) {
@@ -2728,7 +2800,7 @@ export class TournamentService {
             // Check if there's a pending or approved extension for this match
             const hasActiveExtension = tournament.extensionRequests.some((r) =>
                 isExtensionForMatchGame(r, match.id, match.currentGameNumber)
-                && (r.status === `pending` || (r.status === `approved` && now - r.resolvedAt! < extensionMs)));
+                && (r.status === `approved` && now - r.resolvedAt! < extensionMs));
             if (hasActiveExtension) {
                 continue;
             }
@@ -2755,6 +2827,74 @@ export class TournamentService {
                 timeoutWarningMessage,
             ));
             changed = true;
+        }
+
+        return changed;
+    }
+
+    private denyPendingExtension(
+        tournament: TournamentRecord,
+        extension: TournamentExtensionRequest,
+        now: number,
+        activityType: string,
+        activityMessage: string,
+        notificationMessage: string,
+    ): boolean {
+        if (extension.status !== `pending`) {
+            return false;
+        }
+
+        extension.status = `denied`;
+        extension.resolvedByProfileId = null;
+        extension.resolvedAt = now;
+        tournament.activity.unshift(createTournamentActivity(
+            null,
+            activityType,
+            activityMessage,
+        ));
+        this.emitTournamentNotification(extension.requestedByProfileId, {
+            tournamentId: tournament.id,
+            kind: `extension-resolved`,
+            message: notificationMessage,
+        } satisfies TournamentNotificationEvent);
+
+        const match = tournament.matches.find((entry) => entry.id === extension.matchId) ?? null;
+        if (match?.sessionId && getExtensionGameNumber(extension) === match.currentGameNumber) {
+            this.syncSessionTournamentInfo(tournament, match);
+        }
+
+        return true;
+    }
+
+    private expireStalePendingExtensions(
+        tournament: TournamentRecord,
+        now: number,
+        matchId?: string,
+    ): boolean {
+        const extensionMs = getMatchExtensionMinutes(tournament) * 60_000;
+        let changed = false;
+
+        for (const extension of tournament.extensionRequests) {
+            if (extension.status !== `pending`) {
+                continue;
+            }
+
+            if (matchId && extension.matchId !== matchId) {
+                continue;
+            }
+
+            if (now - extension.requestedAt < extensionMs) {
+                continue;
+            }
+
+            changed = this.denyPendingExtension(
+                tournament,
+                extension,
+                now,
+                `extension-expired`,
+                `Extension request from ${extension.requestedByDisplayName} expired without organizer action.`,
+                `Your extension request in ${tournament.name} expired before an organizer responded.`,
+            ) || changed;
         }
 
         return changed;
@@ -2809,19 +2949,26 @@ export class TournamentService {
             }
 
             // Check the join timeout has actually expired
+            const now = Date.now();
             const timeoutMs = tournament.matchJoinTimeoutMinutes * 60_000;
             const extensionMs = getMatchExtensionMinutes(tournament) * 60_000;
+            const expiredPendingExtensions = this.expireStalePendingExtensions(tournament, now, matchId);
+            if (expiredPendingExtensions) {
+                tournament.updatedAt = now;
+                await this.tournamentRepository.saveTournament(tournament);
+                this.broadcastTournamentUpdate(tournament);
+            }
             const hasActiveExtension = tournament.extensionRequests.some((r) =>
                 isExtensionForMatchGame(r, matchId, match.currentGameNumber)
                 && r.status === `approved`
-                && Date.now() - r.resolvedAt! < extensionMs);
+                && now - r.resolvedAt! < extensionMs);
             const effectiveStartedAt = hasActiveExtension
                 ? tournament.extensionRequests
                     .filter((r) => isExtensionForMatchGame(r, matchId, match.currentGameNumber) && r.status === `approved`)
                     .reduce((latest, r) => Math.max(latest, r.resolvedAt!), match.startedAt)
                 : match.startedAt;
 
-            if (Date.now() - effectiveStartedAt < timeoutMs) {
+            if (now - effectiveStartedAt < timeoutMs) {
                 throw new SessionError(`The join timeout has not expired yet.`);
             }
 
@@ -2855,7 +3002,6 @@ export class TournamentService {
                 throw new SessionError(`A win claim is already active for this match.`);
             }
 
-            const now = Date.now();
             const expiresAt = now + kClaimWinCountdownMs;
             const claimState: MatchClaimWinState = {
                 matchId,
@@ -2924,6 +3070,43 @@ export class TournamentService {
         } satisfies SessionClaimWinEvent);
     }
 
+    private cancelActiveClaimsForTournament(tournament: TournamentRecord) {
+        for (const match of tournament.matches) {
+            if (!this.getActiveClaimWinForMatch(match)) {
+                continue;
+            }
+
+            this.cancelClaimWin(match.id, match.sessionId ?? undefined);
+        }
+    }
+
+    private cancelPendingExtensionsForTournament(tournament: TournamentRecord, now: number): boolean {
+        let changed = false;
+
+        for (const extension of tournament.extensionRequests) {
+            changed = this.denyPendingExtension(
+                tournament,
+                extension,
+                now,
+                `extension-cancelled`,
+                `Extension request from ${extension.requestedByDisplayName} was cancelled because the tournament was cancelled.`,
+                `Your extension request in ${tournament.name} was cancelled because the tournament was cancelled.`,
+            ) || changed;
+        }
+
+        return changed;
+    }
+
+    private clearTournamentSessions(tournament: TournamentRecord): void {
+        for (const match of tournament.matches) {
+            if (!match.sessionId || match.state === `completed`) {
+                continue;
+            }
+
+            this.clearSessionTournamentInfo(match.sessionId);
+        }
+    }
+
     private async resolveClaimWin(tournamentId: string, matchId: string) {
         await this.withTournamentLock(tournamentId, async () => {
             const claim = this.activeClaimWins.get(matchId);
@@ -2935,6 +3118,14 @@ export class TournamentService {
             this.activeClaimWins.delete(matchId);
 
             const tournament = await this.requireTournament(tournamentId);
+            if (tournament.status !== `live`) {
+                this.emitSessionClaimWin({
+                    sessionId: claim.sessionId,
+                    state: null,
+                } satisfies SessionClaimWinEvent);
+                return;
+            }
+
             const match = tournament.matches.find((m) => m.id === matchId);
             if (!match || match.state !== `in-progress` || !match.sessionId) {
                 this.emitSessionClaimWin({
@@ -3017,13 +3208,11 @@ export class TournamentService {
                 throw new SessionError(`You are not a participant in this match.`);
             }
 
-            if (match.state !== `in-progress` && match.state !== `ready`) {
+            if (match.state !== `in-progress` || !match.sessionId || !match.startedAt) {
                 throw new SessionError(`This match is not eligible for an extension.`);
             }
 
-            const pendingExtension = tournament.extensionRequests.find((r) =>
-                isExtensionForMatchGame(r, matchId, match.currentGameNumber) && r.status === `pending`);
-            if (pendingExtension) {
+            if (hasPendingExtensionForMatchGame(tournament, matchId, match.currentGameNumber)) {
                 throw new SessionError(`An extension request is already pending for this match.`);
             }
 
@@ -3058,6 +3247,7 @@ export class TournamentService {
                 `extension-requested`,
                 `${user.username} requested a time extension for match ${match.order} in round ${match.round}.`,
             ));
+            this.syncSessionTournamentInfo(tournament, match);
 
             // Notify all organizers (creator + per-tournament organizers)
             const organizerIds = new Set([tournament.createdByProfileId, ...tournament.organizers]);
@@ -3079,7 +3269,7 @@ export class TournamentService {
     }
 
     async resolveExtension(tournamentId: string, extensionId: string, approve: boolean, user: AccountUserProfile): Promise<TournamentDetail> {
-        const tournament = await this.withTournamentLock(tournamentId, async () => {
+        const { tournament, shouldBroadcastUpdate, errorMessage } = await this.withTournamentLock(tournamentId, async () => {
             const tournament = await this.requireTournament(tournamentId);
             this.assertCanManageTournament(user, tournament);
 
@@ -3088,56 +3278,97 @@ export class TournamentService {
                 throw new SessionError(`Extension request not found.`);
             }
 
-            if (extension.status !== `pending`) {
-                throw new SessionError(`This extension request has already been resolved.`);
+            const now = Date.now();
+            let shouldBroadcastUpdate = false;
+            const expiredPendingExtensions = this.expireStalePendingExtensions(tournament, now, extension.matchId);
+            if (expiredPendingExtensions) {
+                tournament.updatedAt = now;
+                shouldBroadcastUpdate = true;
             }
 
-            extension.status = approve ? `approved` : `denied`;
-            extension.resolvedByProfileId = user.id;
-            extension.resolvedAt = Date.now();
+            const refreshedExtension = tournament.extensionRequests.find((entry) => entry.id === extensionId);
+            if (!refreshedExtension) {
+                throw new SessionError(`Extension request not found.`);
+            }
+
+            if (tournament.status !== `live`) {
+                if (shouldBroadcastUpdate) {
+                    await this.tournamentRepository.saveTournament(tournament);
+                }
+
+                return {
+                    tournament,
+                    shouldBroadcastUpdate,
+                    errorMessage: `Extension requests can only be resolved during live tournaments.`,
+                };
+            }
+
+            if (refreshedExtension.status !== `pending`) {
+                if (shouldBroadcastUpdate) {
+                    await this.tournamentRepository.saveTournament(tournament);
+                }
+
+                return {
+                    tournament,
+                    shouldBroadcastUpdate,
+                    errorMessage: refreshedExtension.resolvedByProfileId === null
+                        ? `This extension request has expired.`
+                        : `This extension request has already been resolved.`,
+                };
+            }
+
+            const match = tournament.matches.find((entry) => entry.id === refreshedExtension.matchId) ?? null;
+            if (
+                !match
+                || match.state !== `in-progress`
+                || !match.sessionId
+                || !match.startedAt
+                || getExtensionGameNumber(refreshedExtension) !== match.currentGameNumber
+            ) {
+                this.denyPendingExtension(
+                    tournament,
+                    refreshedExtension,
+                    now,
+                    `extension-invalidated`,
+                    `Extension request from ${refreshedExtension.requestedByDisplayName} expired because the match state changed before it was resolved.`,
+                    `Your extension request in ${tournament.name} expired because the match state changed before it was resolved.`,
+                );
+                tournament.updatedAt = now;
+                await this.tournamentRepository.saveTournament(tournament);
+                return {
+                    tournament,
+                    shouldBroadcastUpdate: true,
+                    errorMessage: `This extension request is no longer eligible to be resolved.`,
+                };
+            }
+
+            refreshedExtension.status = approve ? `approved` : `denied`;
+            refreshedExtension.resolvedByProfileId = user.id;
+            refreshedExtension.resolvedAt = now;
 
             const timeoutMs = tournament.matchJoinTimeoutMinutes * 60_000;
-            const extensionMs = getMatchExtensionMinutes(tournament) * 60_000;
             const extensionMinutes = getMatchExtensionMinutes(tournament);
 
             if (approve) {
                 // Add time on top of the current deadline, don't restart
-                const match = tournament.matches.find((m) => m.id === extension.matchId);
-                if (match && match.startedAt && getExtensionGameNumber(extension) === match.currentGameNumber) {
-                    const now = Date.now();
-                    const oldDeadline = match.startedAt + timeoutMs;
-                    // New startedAt so that new deadline = max(now, oldDeadline) + extensionMs
-                    match.startedAt = Math.max(now, oldDeadline) + extensionMs - timeoutMs;
-
-                    // Sync the session's tournament info so the waiting player sees the updated timer
-                    if (match.sessionId) {
-                        this.sessionManager.updateSessionTournamentInfo(match.sessionId, {
-                            matchStartedAt: match.startedAt,
-                        });
-
-                        // Push a session-updated event so the frontend receives the new matchStartedAt
-                        const sessionInfo = this.sessionManager.getSessionInfo(match.sessionId);
-                        if (sessionInfo) {
-                            this.emitSessionUpdated({
-                                sessionId: match.sessionId as SessionInfo[`id`],
-                                session: { tournament: sessionInfo.tournament },
-                            });
-                        }
-                    }
-                }
+                const extensionMs = getMatchExtensionMinutes(tournament) * 60_000;
+                const oldDeadline = match.startedAt + timeoutMs;
+                // New startedAt so that new deadline = max(now, oldDeadline) + extensionMs
+                match.startedAt = Math.max(now, oldDeadline) + extensionMs - timeoutMs;
             }
+            this.syncSessionTournamentInfo(tournament, match);
 
-            tournament.updatedAt = Date.now();
+            tournament.updatedAt = now;
             tournament.activity.unshift(createTournamentActivity(
                 user,
                 `extension-resolved`,
                 approve
-                    ? `Approved time extension for ${extension.requestedByDisplayName} (+${extensionMinutes} min).`
-                    : `Denied time extension for ${extension.requestedByDisplayName}.`,
+                    ? `Approved time extension for ${refreshedExtension.requestedByDisplayName} (+${extensionMinutes} min).`
+                    : `Denied time extension for ${refreshedExtension.requestedByDisplayName}.`,
             ));
 
             // Notify the requesting player
-            this.emitTournamentNotification(extension.requestedByProfileId, {
+            this.emitTournamentNotification(refreshedExtension.requestedByProfileId, {
                 tournamentId: tournament.id,
                 kind: `extension-resolved`,
                 message: approve
@@ -3146,10 +3377,19 @@ export class TournamentService {
             } satisfies TournamentNotificationEvent);
 
             await this.tournamentRepository.saveTournament(tournament);
-            return tournament;
+            return {
+                tournament,
+                shouldBroadcastUpdate: true,
+                errorMessage: null,
+            };
         });
 
-        this.broadcastTournamentUpdate(tournament);
+        if (shouldBroadcastUpdate) {
+            this.broadcastTournamentUpdate(tournament);
+        }
+        if (errorMessage) {
+            throw new SessionError(errorMessage);
+        }
         return this.toDetail(tournament, user);
     }
 }

--- a/packages/backend/src/tournament/tournamentService.ts
+++ b/packages/backend/src/tournament/tournamentService.ts
@@ -626,31 +626,46 @@ export class TournamentService {
     }
 
     async getTournamentDetail(tournamentId: string, currentUser: AccountUserProfile | null): Promise<TournamentDetail | null> {
-        let tournament = await this.tournamentRepository.getTournament(tournamentId);
+        const { tournament, shouldBroadcastUpdate } = await this.withTournamentLock(tournamentId, async () => {
+            const tournament = await this.tournamentRepository.getTournament(tournamentId);
+            if (!tournament) {
+                return {
+                    tournament: null,
+                    shouldBroadcastUpdate: false,
+                };
+            }
+
+            let shouldBroadcastUpdate = false;
+
+            /* Eagerly reconcile live tournaments so the detail is always fresh */
+            if (tournament.status === `live`) {
+                const changed = await this.reconcileLiveTournamentRecord(tournament);
+                const timeoutChanged = tournament.status === `live`
+                    ? this.checkMatchTimeouts(tournament)
+                    : false;
+                const participantStatusChanged = this.refreshParticipantStatuses(tournament);
+                if (changed || timeoutChanged || participantStatusChanged) {
+                    tournament.updatedAt = Date.now();
+                    await this.tournamentRepository.saveTournament(tournament);
+                    shouldBroadcastUpdate = true;
+                }
+            }
+
+            return {
+                tournament,
+                shouldBroadcastUpdate,
+            };
+        });
+
         if (!tournament) {
             return null;
         }
-        let autoSubscribedOnView = false;
 
-        /* Eagerly reconcile live tournaments so the detail is always fresh */
-        if (tournament.status === `live`) {
-            const changed = await this.reconcileLiveTournamentRecord(tournament);
-            const timeoutChanged = tournament.status === `live`
-                ? this.checkMatchTimeouts(tournament)
-                : false;
-            const participantStatusChanged = this.refreshParticipantStatuses(tournament);
-            if (changed) {
-                tournament.updatedAt = Date.now();
-                await this.tournamentRepository.saveTournament(tournament);
-                this.broadcastTournamentUpdate(tournament);
-                tournament = await this.tournamentRepository.getTournament(tournamentId) ?? tournament;
-            } else if (timeoutChanged || participantStatusChanged) {
-                tournament.updatedAt = Date.now();
-                await this.tournamentRepository.saveTournament(tournament);
-                this.broadcastTournamentUpdate(tournament);
-                tournament = await this.tournamentRepository.getTournament(tournamentId) ?? tournament;
-            }
+        if (shouldBroadcastUpdate) {
+            this.broadcastTournamentUpdate(tournament);
         }
+
+        let autoSubscribedOnView = false;
 
         /* Auto-subscribe on view */
         if (currentUser) {
@@ -2848,6 +2863,7 @@ export class TournamentService {
                 return;
             }
 
+            clearTimeout(claim.timer);
             this.activeClaimWins.delete(matchId);
 
             const tournament = await this.requireTournament(tournamentId);
@@ -2882,6 +2898,7 @@ export class TournamentService {
             }
 
             // Award walkover to claimant
+            const sessionId = match.sessionId;
             this.completeMatchSet(tournament, match, claim.claimantProfileId, `walkover`);
             tournament.activity.unshift(createTournamentActivity(
                 null,
@@ -2908,9 +2925,9 @@ export class TournamentService {
                 }
             }
 
-            if (match.sessionId) {
+            if (sessionId) {
                 this.emitSessionClaimWin({
-                    sessionId: match.sessionId,
+                    sessionId,
                     state: null,
                 } satisfies SessionClaimWinEvent);
             }

--- a/packages/backend/src/tournament/tournamentService.ts
+++ b/packages/backend/src/tournament/tournamentService.ts
@@ -1722,13 +1722,13 @@ export class TournamentService {
 
         changed = this.refreshParticipantStatuses(tournament) || changed;
 
-        if (changed) {
-            tournament.updatedAt = Date.now();
-        }
-
         if (tournament.activity.length > 200) {
             tournament.activity = tournament.activity.slice(0, 200);
             changed = true;
+        }
+
+        if (changed) {
+            tournament.updatedAt = Date.now();
         }
 
         return changed;

--- a/packages/backend/src/tournament/tournamentService.ts
+++ b/packages/backend/src/tournament/tournamentService.ts
@@ -1254,9 +1254,13 @@ export class TournamentService {
                 throw new SessionError(`Only active matches can be reopened automatically in v1.`);
             }
 
+            const oldSessionId = match.sessionId;
             match.sessionId = null;
             match.state = `ready`;
             match.startedAt = null;
+            if (oldSessionId) {
+                this.clearSessionTournamentInfo(oldSessionId);
+            }
             tournament.updatedAt = Date.now();
             tournament.activity.unshift(createTournamentActivity(user, `match-reopened`, `Reopened round ${match.round}, match ${match.order}.`));
             await this.reconcileTournamentRecord(tournament);

--- a/packages/backend/src/tournament/tournamentService.ts
+++ b/packages/backend/src/tournament/tournamentService.ts
@@ -2499,6 +2499,8 @@ export class TournamentService {
             matchStartedAt,
             leftDisplayName: match.slots[0].displayName,
             rightDisplayName: match.slots[1].displayName,
+            leftProfileId: match.slots[0].profileId,
+            rightProfileId: match.slots[1].profileId,
         };
     }
 

--- a/packages/backend/src/tournament/tournamentService.ts
+++ b/packages/backend/src/tournament/tournamentService.ts
@@ -92,6 +92,16 @@ function countCheckedInParticipants(tournament: TournamentRecord): number {
     return tournament.participants.filter((participant) => isActiveParticipant(participant) && participant.checkedInAt !== null).length;
 }
 
+function isPreStartTournamentStatus(status: TournamentRecord[`status`]): boolean {
+    return status === `registration-open`
+        || status === `check-in-open`
+        || status === `waitlist-open`;
+}
+
+function shouldEagerlyReconcileTournamentStatus(status: TournamentRecord[`status`]): boolean {
+    return isPreStartTournamentStatus(status) || status === `live`;
+}
+
 function getMinimumParticipantsToStart(format: TournamentFormat): number {
     return format === `swiss` ? 2 : 4;
 }
@@ -635,25 +645,11 @@ export class TournamentService {
                 };
             }
 
-            let shouldBroadcastUpdate = false;
-
-            /* Eagerly reconcile live tournaments so the detail is always fresh */
-            if (tournament.status === `live`) {
-                const changed = await this.reconcileLiveTournamentRecord(tournament);
-                const timeoutChanged = tournament.status === `live`
-                    ? this.checkMatchTimeouts(tournament)
-                    : false;
-                const participantStatusChanged = this.refreshParticipantStatuses(tournament);
-                if (changed || timeoutChanged || participantStatusChanged) {
-                    tournament.updatedAt = Date.now();
-                    await this.tournamentRepository.saveTournament(tournament);
-                    shouldBroadcastUpdate = true;
-                }
-            }
-
             return {
                 tournament,
-                shouldBroadcastUpdate,
+                shouldBroadcastUpdate: shouldEagerlyReconcileTournamentStatus(tournament.status)
+                    ? await this.reconcileTournamentRecord(tournament)
+                    : false,
             };
         });
 
@@ -714,6 +710,7 @@ export class TournamentService {
         const tournament = await this.withTournamentLock(tournamentId, async () => {
             const tournament = await this.requireTournament(tournamentId);
             this.assertCanManageTournament(user, tournament);
+            await this.reconcileTournamentForMutation(tournament);
 
             if (tournament.status === `live` || tournament.status === `completed` || tournament.status === `cancelled`) {
                 throw new SessionError(`Tournament settings can only be changed before the event goes live.`);
@@ -803,6 +800,7 @@ export class TournamentService {
     async registerCurrentUser(tournamentId: string, user: AccountUserProfile): Promise<TournamentDetail> {
         const tournament = await this.withTournamentLock(tournamentId, async () => {
             const tournament = await this.requireTournament(tournamentId);
+            await this.reconcileTournamentForMutation(tournament);
             const canRegister = tournament.status === `registration-open`
                 || (tournament.status === `check-in-open` && tournament.lateRegistrationEnabled);
             if (!canRegister) {
@@ -872,6 +870,7 @@ export class TournamentService {
             if (!canManageTournament(user, tournament)) {
                 throw new SessionError(`Only organizers can reorder seeds.`);
             }
+            await this.reconcileTournamentForMutation(tournament);
 
             if (tournament.status !== `registration-open` && tournament.status !== `check-in-open`) {
                 throw new SessionError(`Seeds can only be reordered before the tournament starts.`);
@@ -918,6 +917,7 @@ export class TournamentService {
     async withdrawCurrentUser(tournamentId: string, user: AccountUserProfile): Promise<TournamentDetail> {
         const tournament = await this.withTournamentLock(tournamentId, async () => {
             const tournament = await this.requireTournament(tournamentId);
+            await this.reconcileTournamentForMutation(tournament);
             const participant = tournament.participants.find((entry) =>
                 entry.profileId === user.id && (isActiveParticipant(entry) || entry.status === `waitlisted`));
             if (!participant) {
@@ -959,6 +959,7 @@ export class TournamentService {
     async checkInCurrentUser(tournamentId: string, user: AccountUserProfile): Promise<TournamentDetail> {
         const tournament = await this.withTournamentLock(tournamentId, async () => {
             const tournament = await this.requireTournament(tournamentId);
+            await this.reconcileTournamentForMutation(tournament);
 
             // Waitlist check-in: waitlisted player claiming a freed slot
             if (tournament.status === `waitlist-open`) {
@@ -1010,6 +1011,7 @@ export class TournamentService {
         const tournament = await this.withTournamentLock(tournamentId, async () => {
             const tournament = await this.requireTournament(tournamentId);
             this.assertCanManageTournament(user, tournament);
+            await this.reconcileTournamentForMutation(tournament);
 
             if (tournament.status === `live`) {
                 throw new SessionError(`Use participant replacement once the tournament is live.`);
@@ -1062,6 +1064,7 @@ export class TournamentService {
         const tournament = await this.withTournamentLock(tournamentId, async () => {
             const tournament = await this.requireTournament(tournamentId);
             this.assertCanManageTournament(user, tournament);
+            await this.reconcileTournamentForMutation(tournament);
 
             const participant = tournament.participants.find((entry) => entry.profileId === profileId && isActiveParticipant(entry));
             if (!participant) {
@@ -1100,6 +1103,7 @@ export class TournamentService {
         const tournament = await this.withTournamentLock(tournamentId, async () => {
             const tournament = await this.requireTournament(tournamentId);
             this.assertCanManageTournament(user, tournament);
+            await this.reconcileTournamentForMutation(tournament);
 
             const currentParticipant = tournament.participants.find((entry) => entry.profileId === request.profileId && isActiveParticipant(entry));
             if (!currentParticipant) {
@@ -1163,15 +1167,27 @@ export class TournamentService {
     }
 
     async startTournament(tournamentId: string, user: AccountUserProfile): Promise<TournamentDetail> {
-        const tournament = await this.withTournamentLock(tournamentId, async () => {
+        const { tournament, shouldBroadcastUpdate } = await this.withTournamentLock(tournamentId, async () => {
             const tournament = await this.requireTournament(tournamentId);
             this.assertCanManageTournament(user, tournament);
+            const stateChanged = await this.reconcileTournamentForMutation(tournament);
+            if (tournament.status === `live`) {
+                return {
+                    tournament,
+                    shouldBroadcastUpdate: stateChanged,
+                };
+            }
             await this.startTournamentRecord(tournament, user);
             await this.tournamentRepository.saveTournament(tournament);
-            return tournament;
+            return {
+                tournament,
+                shouldBroadcastUpdate: true,
+            };
         });
 
-        this.broadcastTournamentUpdate(tournament);
+        if (shouldBroadcastUpdate) {
+            this.broadcastTournamentUpdate(tournament);
+        }
         return this.toDetail(tournament, user);
     }
 
@@ -1238,44 +1254,55 @@ export class TournamentService {
     }
 
     async unsubscribeFromTournament(tournamentId: string, user: AccountUserProfile, transferTo?: string): Promise<void> {
-        const tournament = await this.requireTournament(tournamentId);
-        const isCreator = tournament.createdByProfileId === user.id;
-        const isOrganizer = tournament.organizers?.includes(user.id) === true;
+        const { tournament, shouldBroadcastUpdate } = await this.withTournamentLock(tournamentId, async () => {
+            const tournament = await this.requireTournament(tournamentId);
+            const isCreator = tournament.createdByProfileId === user.id;
+            const isOrganizer = tournament.organizers?.includes(user.id) === true;
+            let shouldBroadcastUpdate = false;
 
-        if (isCreator) {
-            const otherOrganizers = (tournament.organizers ?? []).filter((id) => id !== user.id);
-            if (otherOrganizers.length === 0 && tournament.status !== `completed` && tournament.status !== `cancelled`) {
-                throw new SessionError(`You are the only organizer. Add another organizer before unsubscribing, or cancel the tournament.`);
-            }
-
-            if (!transferTo) {
-                if (otherOrganizers.length > 0 && tournament.status !== `completed` && tournament.status !== `cancelled`) {
-                    throw new SessionError(`Choose a new primary organizer before unsubscribing.`);
-                }
-            } else {
-                if (!otherOrganizers.includes(transferTo)) {
-                    throw new SessionError(`The selected user is not an organizer of this tournament.`);
+            if (isCreator) {
+                const otherOrganizers = (tournament.organizers ?? []).filter((id) => id !== user.id);
+                if (otherOrganizers.length === 0 && tournament.status !== `completed` && tournament.status !== `cancelled`) {
+                    throw new SessionError(`You are the only organizer. Add another organizer before unsubscribing, or cancel the tournament.`);
                 }
 
-                tournament.createdByProfileId = transferTo;
-                tournament.organizers = otherOrganizers.filter((id) => id !== transferTo);
+                if (!transferTo) {
+                    if (otherOrganizers.length > 0 && tournament.status !== `completed` && tournament.status !== `cancelled`) {
+                        throw new SessionError(`Choose a new primary organizer before unsubscribing.`);
+                    }
+                } else {
+                    if (!otherOrganizers.includes(transferTo)) {
+                        throw new SessionError(`The selected user is not an organizer of this tournament.`);
+                    }
+
+                    tournament.createdByProfileId = transferTo;
+                    tournament.organizers = otherOrganizers.filter((id) => id !== transferTo);
+                    tournament.updatedAt = Date.now();
+                    tournament.activity.unshift(createTournamentActivity(
+                        user,
+                        `organizer-transferred`,
+                        `${user.username} transferred tournament ownership.`,
+                    ));
+                    await this.tournamentRepository.saveTournament(tournament);
+                    shouldBroadcastUpdate = true;
+                }
+            } else if (isOrganizer) {
+                tournament.organizers = (tournament.organizers ?? []).filter((id) => id !== user.id);
                 tournament.updatedAt = Date.now();
-                tournament.activity.unshift(createTournamentActivity(
-                    user,
-                    `organizer-transferred`,
-                    `${user.username} transferred tournament ownership.`,
-                ));
                 await this.tournamentRepository.saveTournament(tournament);
-                this.broadcastTournamentUpdate(tournament);
+                shouldBroadcastUpdate = true;
             }
-        } else if (isOrganizer) {
-            tournament.organizers = (tournament.organizers ?? []).filter((id) => id !== user.id);
-            tournament.updatedAt = Date.now();
-            await this.tournamentRepository.saveTournament(tournament);
+
+            await this.tournamentRepository.removeSubscriber(tournamentId, user.id);
+            return {
+                tournament,
+                shouldBroadcastUpdate,
+            };
+        });
+
+        if (shouldBroadcastUpdate) {
             this.broadcastTournamentUpdate(tournament);
         }
-
-        await this.tournamentRepository.removeSubscriber(tournamentId, user.id);
     }
 
     async grantTournamentOrganizer(tournamentId: string, user: AccountUserProfile, profileId: string): Promise<TournamentDetail> {
@@ -1492,7 +1519,24 @@ export class TournamentService {
         return Math.min(size, maxPlayers);
     }
 
-    private async reconcileTournamentRecord(tournament: TournamentRecord): Promise<void> {
+    private async reconcileTournamentForMutation(tournament: TournamentRecord): Promise<boolean> {
+        if (!isPreStartTournamentStatus(tournament.status)) {
+            return false;
+        }
+
+        return await this.reconcileTournamentRecord(tournament);
+    }
+
+    private async reconcileTournamentRecord(tournament: TournamentRecord): Promise<boolean> {
+        const changed = await this.applyTournamentReconciliation(tournament);
+        if (changed) {
+            await this.tournamentRepository.saveTournament(tournament);
+        }
+
+        return changed;
+    }
+
+    private async applyTournamentReconciliation(tournament: TournamentRecord): Promise<boolean> {
         const now = Date.now();
         let changed = false;
 
@@ -1626,9 +1670,10 @@ export class TournamentService {
 
         if (tournament.activity.length > 200) {
             tournament.activity = tournament.activity.slice(0, 200);
+            changed = true;
         }
 
-        await this.tournamentRepository.saveTournament(tournament);
+        return changed;
     }
 
     private getRoundDelayDependencyMatches(tournament: TournamentRecord, match: TournamentMatch): TournamentMatch[] {

--- a/packages/backend/src/tournament/tournamentService.ts
+++ b/packages/backend/src/tournament/tournamentService.ts
@@ -53,6 +53,7 @@ type ActiveClaimWin = {
     tournamentId: string;
     matchId: string;
     sessionId: string;
+    gameNumber: number;
     claimantProfileId: string;
     startedAt: number;
     expiresAt: number;
@@ -113,6 +114,14 @@ function canUserAccessTournamentRegistration(tournament: TournamentRecord, userI
 
 function getWinsRequired(bestOf: 1 | 3 | 5 | 7): number {
     return Math.floor(bestOf / 2) + 1;
+}
+
+function getExtensionGameNumber(extension: Pick<TournamentExtensionRequest, `gameNumber`>): number {
+    return extension.gameNumber ?? 1;
+}
+
+function isExtensionForMatchGame(extension: TournamentExtensionRequest, matchId: string, gameNumber: number): boolean {
+    return extension.matchId === matchId && getExtensionGameNumber(extension) === gameNumber;
 }
 
 function normalizeDescription(value: string | null | undefined): string | null {
@@ -495,12 +504,14 @@ function toDetail(
     profileMap?: Map<string, string>,
     autoSubscribedOnView = false,
     isMatchWaitingForPlayers?: (match: TournamentMatch) => boolean,
+    getMatchClaimWinExpiresAt?: (match: TournamentMatch) => number | null,
 ): TournamentDetail {
     return {
         ...toSummary(tournament),
         participants: tournament.participants.map(cloneParticipant),
         matches: tournament.matches.map((match) => ({
             ...cloneMatch(match),
+            claimWinExpiresAt: getMatchClaimWinExpiresAt?.(match) ?? null,
             waitingForPlayers: isMatchWaitingForPlayers?.(match) ?? false,
         })),
         standings: getTournamentStandings(tournament),
@@ -554,6 +565,7 @@ export class TournamentService {
             profileMap,
             autoSubscribedOnView,
             (match) => this.isMatchWaitingForPlayers(match),
+            (match) => this.getActiveClaimWinForMatch(match)?.expiresAt ?? null,
         );
     }
 
@@ -1839,8 +1851,15 @@ export class TournamentService {
                 }
 
                 if (match.state !== `in-progress`) {
+                    const matchStartedAt = match.startedAt ?? Date.now();
                     match.state = `in-progress`;
-                    match.startedAt ??= Date.now();
+                    match.startedAt = matchStartedAt;
+                    this.sessionManager.updateSessionTournamentInfo(match.sessionId, {
+                        currentGameNumber: match.currentGameNumber,
+                        leftWins: match.leftWins,
+                        rightWins: match.rightWins,
+                        matchStartedAt,
+                    });
                     return true;
                 }
 
@@ -1875,6 +1894,7 @@ export class TournamentService {
         }
 
         try {
+            const matchStartedAt = Date.now();
             const response = this.sessionManager.createSession({
                 client: kTournamentSystemClient,
                 lobbyOptions: {
@@ -1884,12 +1904,12 @@ export class TournamentService {
                     firstPlayer: `random`,
                 },
                 reservedPlayerProfileIds: this.getReservedSeatOrder(match),
-                tournament: this.toSessionTournamentInfo(tournament, match),
+                tournament: this.toSessionTournamentInfo(tournament, match, matchStartedAt),
             } satisfies CreateSessionParams);
 
             match.sessionId = response.sessionId;
             match.state = `in-progress`;
-            match.startedAt ??= Date.now();
+            match.startedAt = matchStartedAt;
             this.notifyMatchReady(tournament, match);
             return true;
         } catch (error: unknown) {
@@ -1917,6 +1937,9 @@ export class TournamentService {
         if (match.gameIds.includes(gameId)) {
             return;
         }
+        if (match.sessionId) {
+            this.cancelClaimWin(match.id, match.sessionId);
+        }
         match.gameIds.push(gameId);
 
         const winnerSlotIndex = match.slots.findIndex((slot) => slot.profileId === winnerProfileId);
@@ -1936,6 +1959,7 @@ export class TournamentService {
             this.completeMatchSet(tournament, match, winnerProfileId, `played`);
         } else {
             match.state = `ready`;
+            match.startedAt = null;
         }
     }
 
@@ -2292,7 +2316,7 @@ export class TournamentService {
         return session.players.find((player) => player.id === winningParticipantId)?.profileId ?? null;
     }
 
-    private toSessionTournamentInfo(tournament: TournamentRecord, match: TournamentMatch): SessionTournamentInfo {
+    private toSessionTournamentInfo(tournament: TournamentRecord, match: TournamentMatch, matchStartedAt = match.startedAt ?? Date.now()): SessionTournamentInfo {
         return {
             tournamentId: tournament.id,
             tournamentName: tournament.name,
@@ -2306,7 +2330,7 @@ export class TournamentService {
             rightWins: match.rightWins,
             matchJoinTimeoutMs: tournament.matchJoinTimeoutMinutes * 60_000,
             matchExtensionMs: getMatchExtensionMinutes(tournament) * 60_000,
-            matchStartedAt: match.startedAt ?? Date.now(),
+            matchStartedAt,
             leftDisplayName: match.slots[0].displayName,
             rightDisplayName: match.slots[1].displayName,
         };
@@ -2593,7 +2617,7 @@ export class TournamentService {
             const connectedPlayerCount = session.players.filter((p) => p.connection.status === `connected`).length;
             if (connectedPlayerCount >= 2) {
                 // Cancel any active claim — opponent joined
-                if (this.activeClaimWins.has(match.id)) {
+                if (this.getActiveClaimWinForMatch(match)) {
                     this.cancelClaimWin(match.id, match.sessionId);
                     tournament.activity.unshift(createTournamentActivity(
                         null,
@@ -2618,7 +2642,8 @@ export class TournamentService {
 
             // Check if there's a pending or approved extension for this match
             const hasActiveExtension = tournament.extensionRequests.some((r) =>
-                r.matchId === match.id && (r.status === `pending` || (r.status === `approved` && now - r.resolvedAt! < extensionMs)));
+                isExtensionForMatchGame(r, match.id, match.currentGameNumber)
+                && (r.status === `pending` || (r.status === `approved` && now - r.resolvedAt! < extensionMs)));
             if (hasActiveExtension) {
                 continue;
             }
@@ -2650,6 +2675,20 @@ export class TournamentService {
         return changed;
     }
 
+    private getActiveClaimWinForMatch(match: TournamentMatch): ActiveClaimWin | null {
+        const claim = this.activeClaimWins.get(match.id);
+        if (!claim) {
+            return null;
+        }
+
+        if (claim.sessionId !== match.sessionId || claim.gameNumber !== match.currentGameNumber) {
+            this.cancelClaimWin(match.id, claim.sessionId);
+            return null;
+        }
+
+        return claim;
+    }
+
     getActiveClaimWin(matchId: string): MatchClaimWinState | null {
         const claim = this.activeClaimWins.get(matchId);
         if (!claim) {
@@ -2658,6 +2697,7 @@ export class TournamentService {
 
         return {
             matchId: claim.matchId,
+            gameNumber: claim.gameNumber,
             claimantProfileId: claim.claimantProfileId,
             startedAt: claim.startedAt,
             expiresAt: claim.expiresAt,
@@ -2687,10 +2727,12 @@ export class TournamentService {
             const timeoutMs = tournament.matchJoinTimeoutMinutes * 60_000;
             const extensionMs = getMatchExtensionMinutes(tournament) * 60_000;
             const hasActiveExtension = tournament.extensionRequests.some((r) =>
-                r.matchId === matchId && (r.status === `approved` && Date.now() - r.resolvedAt! < extensionMs));
+                isExtensionForMatchGame(r, matchId, match.currentGameNumber)
+                && r.status === `approved`
+                && Date.now() - r.resolvedAt! < extensionMs);
             const effectiveStartedAt = hasActiveExtension
                 ? tournament.extensionRequests
-                    .filter((r) => r.matchId === matchId && r.status === `approved`)
+                    .filter((r) => isExtensionForMatchGame(r, matchId, match.currentGameNumber) && r.status === `approved`)
                     .reduce((latest, r) => Math.max(latest, r.resolvedAt!), match.startedAt)
                 : match.startedAt;
 
@@ -2700,7 +2742,7 @@ export class TournamentService {
 
             // Check there's no pending extension blocking the claim
             const hasPendingExtension = tournament.extensionRequests.some((r) =>
-                r.matchId === matchId && r.status === `pending`);
+                isExtensionForMatchGame(r, matchId, match.currentGameNumber) && r.status === `pending`);
             if (hasPendingExtension) {
                 throw new SessionError(`A pending extension request is blocking this claim. Wait for the organizer to respond.`);
             }
@@ -2724,7 +2766,7 @@ export class TournamentService {
             }
 
             // Check for existing claim on this match
-            if (this.activeClaimWins.has(matchId)) {
+            if (this.getActiveClaimWinForMatch(match)) {
                 throw new SessionError(`A win claim is already active for this match.`);
             }
 
@@ -2732,6 +2774,7 @@ export class TournamentService {
             const expiresAt = now + kClaimWinCountdownMs;
             const claimState: MatchClaimWinState = {
                 matchId,
+                gameNumber: match.currentGameNumber,
                 claimantProfileId: user.id,
                 startedAt: now,
                 expiresAt,
@@ -2745,6 +2788,7 @@ export class TournamentService {
                 tournamentId,
                 matchId,
                 sessionId: match.sessionId,
+                gameNumber: match.currentGameNumber,
                 claimantProfileId: user.id,
                 startedAt: now,
                 expiresAt,
@@ -2780,7 +2824,7 @@ export class TournamentService {
         });
     }
 
-    private cancelClaimWin(matchId: string, sessionId: string) {
+    private cancelClaimWin(matchId: string, sessionId?: string) {
         const claim = this.activeClaimWins.get(matchId);
         if (!claim) {
             return;
@@ -2790,7 +2834,7 @@ export class TournamentService {
         this.activeClaimWins.delete(matchId);
 
         this.emitSessionClaimWin({
-            sessionId,
+            sessionId: sessionId ?? claim.sessionId,
             state: null,
         } satisfies SessionClaimWinEvent);
     }
@@ -2807,6 +2851,18 @@ export class TournamentService {
             const tournament = await this.requireTournament(tournamentId);
             const match = tournament.matches.find((m) => m.id === matchId);
             if (!match || match.state !== `in-progress` || !match.sessionId) {
+                this.emitSessionClaimWin({
+                    sessionId: claim.sessionId,
+                    state: null,
+                } satisfies SessionClaimWinEvent);
+                return;
+            }
+
+            if (claim.sessionId !== match.sessionId || claim.gameNumber !== match.currentGameNumber) {
+                this.emitSessionClaimWin({
+                    sessionId: claim.sessionId,
+                    state: null,
+                } satisfies SessionClaimWinEvent);
                 return;
             }
 
@@ -2879,26 +2935,27 @@ export class TournamentService {
             }
 
             const pendingExtension = tournament.extensionRequests.find((r) =>
-                r.matchId === matchId && r.status === `pending`);
+                isExtensionForMatchGame(r, matchId, match.currentGameNumber) && r.status === `pending`);
             if (pendingExtension) {
                 throw new SessionError(`An extension request is already pending for this match.`);
             }
 
-            // Enforce 1 extension per player per match
+            // Enforce 1 extension per player per game in a best-of series.
             const userExtensionCount = tournament.extensionRequests.filter((r) =>
-                r.matchId === matchId && r.requestedByProfileId === user.id).length;
+                isExtensionForMatchGame(r, matchId, match.currentGameNumber) && r.requestedByProfileId === user.id).length;
             if (userExtensionCount >= 1) {
                 throw new SessionError(`You have already used your extension request for this match.`);
             }
 
             // Cancel any active claim win — extension blocks it
-            if (match.sessionId && this.activeClaimWins.has(matchId)) {
+            if (match.sessionId && this.getActiveClaimWinForMatch(match)) {
                 this.cancelClaimWin(matchId, match.sessionId);
             }
 
             const extensionRequest: TournamentExtensionRequest = {
                 id: randomUUID(),
                 matchId,
+                gameNumber: match.currentGameNumber,
                 requestedByProfileId: user.id,
                 requestedByDisplayName: user.username,
                 requestedAt: Date.now(),
@@ -2959,7 +3016,7 @@ export class TournamentService {
             if (approve) {
                 // Add time on top of the current deadline, don't restart
                 const match = tournament.matches.find((m) => m.id === extension.matchId);
-                if (match && match.startedAt) {
+                if (match && match.startedAt && getExtensionGameNumber(extension) === match.currentGameNumber) {
                     const now = Date.now();
                     const oldDeadline = match.startedAt + timeoutMs;
                     // New startedAt so that new deadline = max(now, oldDeadline) + extensionMs

--- a/packages/backend/src/tournament/tournamentService.ts
+++ b/packages/backend/src/tournament/tournamentService.ts
@@ -1631,13 +1631,36 @@ export class TournamentService {
         await this.tournamentRepository.saveTournament(tournament);
     }
 
+    private getRoundDelayDependencyMatches(tournament: TournamentRecord, match: TournamentMatch): TournamentMatch[] {
+        if (match.bracket === `grand-final-reset`) {
+            return tournament.matches.filter((entry) => entry.bracket === `grand-final`);
+        }
+
+        const dependencyIds = new Set(match.slots.flatMap((slot) => {
+            const source = slot.source;
+            if (!source || source.type === `seed`) {
+                return [];
+            }
+
+            return [source.matchId];
+        }));
+        if (dependencyIds.size > 0) {
+            return tournament.matches.filter((entry) => dependencyIds.has(entry.id));
+        }
+
+        if (match.round <= 1) {
+            return [];
+        }
+
+        return tournament.matches.filter(
+            (entry) => entry.bracket === match.bracket && entry.round === match.round - 1,
+        );
+    }
+
     private canMatchBecomeReady(tournament: TournamentRecord, match: TournamentMatch): boolean {
         if (tournament.roundDelayMinutes <= 0) return true;
-        if (match.round <= 1) return true;
 
-        const previousRoundMatches = tournament.matches.filter(
-            (m) => m.bracket === match.bracket && m.round === match.round - 1,
-        );
+        const previousRoundMatches = this.getRoundDelayDependencyMatches(tournament, match);
         if (previousRoundMatches.length === 0) return true;
 
         const allPreviousCompleted = previousRoundMatches.every((m) => m.state === `completed`);
@@ -2066,7 +2089,7 @@ export class TournamentService {
                     bracket: `grand-final-reset`,
                     round: 1,
                     order: 1,
-                    state: `ready`,
+                    state: `pending`,
                     bestOf: tournament.seriesSettings.grandFinalBestOf,
                     slots: match.slots.map((slot) => ({
                         ...slot,

--- a/packages/backend/src/tournament/tournamentService.ts
+++ b/packages/backend/src/tournament/tournamentService.ts
@@ -2792,16 +2792,25 @@ export class TournamentService {
             }
 
             // Already sent a warning for this match since the current timeout window started?
+            // Use the latest approved extension's resolvedAt as the window floor so that
+            // a pre-extension warning doesn't suppress a re-notification after extension expires.
+            const latestApprovedExtension = tournament.extensionRequests
+                .filter((r) => isExtensionForMatchGame(r, match.id, match.currentGameNumber) && r.status === `approved` && r.resolvedAt !== null)
+                .sort((a, b) => (b.resolvedAt ?? 0) - (a.resolvedAt ?? 0))[0] ?? null;
+            const warnWindowStart = latestApprovedExtension?.resolvedAt
+                ? Math.max(match.startedAt!, latestApprovedExtension.resolvedAt)
+                : match.startedAt!;
+
             const timeoutWarningMessage = `${describeTournamentMatch(match)} timed out — waiting for player(s) to join.`;
             const alreadyWarned = tournament.activity.some((activity) =>
                 activity.type === `timeout-warning`
                 && activity.message === timeoutWarningMessage
-                && activity.timestamp >= match.startedAt!);
+                && activity.timestamp >= warnWindowStart);
             if (alreadyWarned) {
                 continue;
             }
 
-            // Check if there's a pending or approved extension for this match
+            // Check if there's still an active (non-expired) extension for this match
             const hasActiveExtension = tournament.extensionRequests.some((r) =>
                 isExtensionForMatchGame(r, match.id, match.currentGameNumber)
                 && (r.status === `approved` && now - r.resolvedAt! < extensionMs));

--- a/packages/backend/src/tournament/tournamentService.ts
+++ b/packages/backend/src/tournament/tournamentService.ts
@@ -2482,6 +2482,10 @@ export class TournamentService {
     }
 
     private toSessionTournamentInfo(tournament: TournamentRecord, match: TournamentMatch, matchStartedAt = match.startedAt ?? Date.now()): SessionTournamentInfo {
+        const timeoutMs = tournament.matchJoinTimeoutMinutes * 60_000;
+        const matchJoinTimeoutInMs = timeoutMs > 0
+            ? Math.max(0, matchStartedAt + timeoutMs - Date.now())
+            : null;
         return {
             tournamentId: tournament.id,
             tournamentName: tournament.name,
@@ -2493,10 +2497,10 @@ export class TournamentService {
             currentGameNumber: match.currentGameNumber,
             leftWins: match.leftWins,
             rightWins: match.rightWins,
-            matchJoinTimeoutMs: tournament.matchJoinTimeoutMinutes * 60_000,
+            matchJoinTimeoutMs: timeoutMs,
             matchExtensionMs: getMatchExtensionMinutes(tournament) * 60_000,
             pendingExtension: hasPendingExtensionForMatchGame(tournament, match.id, match.currentGameNumber),
-            matchStartedAt,
+            matchJoinTimeoutInMs,
             leftDisplayName: match.slots[0].displayName,
             rightDisplayName: match.slots[1].displayName,
             leftProfileId: match.slots[0].profileId,
@@ -2946,7 +2950,7 @@ export class TournamentService {
             gameNumber: claim.gameNumber,
             claimantProfileId: claim.claimantProfileId,
             startedAt: claim.startedAt,
-            expiresAt: claim.expiresAt,
+            expiresInMs: Math.max(0, claim.expiresAt - Date.now()),
         };
     }
 
@@ -3029,7 +3033,7 @@ export class TournamentService {
                 gameNumber: match.currentGameNumber,
                 claimantProfileId: user.id,
                 startedAt: now,
-                expiresAt,
+                expiresInMs: kClaimWinCountdownMs,
             };
 
             const timer = setTimeout(() => {

--- a/packages/backend/src/tournament/tournamentSwiss.ts
+++ b/packages/backend/src/tournament/tournamentSwiss.ts
@@ -95,6 +95,30 @@ function buildPlayedPairings(matches: TournamentMatch[]): Set<string> {
     return playedPairings;
 }
 
+function buildPlayedPairingsByRound(matches: TournamentMatch[]): Map<number, Set<string>> {
+    const byRound = new Map<number, Set<string>>();
+    for (const match of matches) {
+        if (match.bracket !== `swiss` || match.state !== `completed`) {
+            continue;
+        }
+
+        const [leftProfileId, rightProfileId] = match.slots.map((slot) => slot.profileId);
+        if (!leftProfileId || !rightProfileId) {
+            continue;
+        }
+
+        const key = getPairingKey(leftProfileId, rightProfileId);
+        const existing = byRound.get(match.round);
+        if (existing) {
+            existing.add(key);
+        } else {
+            byRound.set(match.round, new Set([key]));
+        }
+    }
+
+    return byRound;
+}
+
 function pairParticipants(
     participants: SeededSwissParticipant[],
     playedPairings: Set<string>,
@@ -277,7 +301,26 @@ export function buildSwissRoundMatches(options: {
 
     const pairings = pairParticipants(participantsForPairing, playedPairings);
     if (!pairings) {
-        const relaxedPairings = pairParticipants(participantsForPairing, new Set());
+        const pairingsByRound = buildPlayedPairingsByRound(options.existingMatches);
+        const rounds = [...pairingsByRound.keys()].sort((a, b) => a - b);
+
+        let relaxedPairings: ReturnType<typeof pairParticipants> = null;
+        for (let relaxCount = 1; relaxCount <= rounds.length; relaxCount += 1) {
+            const relaxedRounds = new Set(rounds.slice(0, relaxCount));
+            const constrainedPairings = new Set<string>();
+            for (const [round, roundPairings] of pairingsByRound) {
+                if (!relaxedRounds.has(round)) {
+                    for (const key of roundPairings) {
+                        constrainedPairings.add(key);
+                    }
+                }
+            }
+            relaxedPairings = pairParticipants(participantsForPairing, constrainedPairings);
+            if (relaxedPairings) {
+                break;
+            }
+        }
+
         if (!relaxedPairings) {
             return [];
         }

--- a/packages/backend/src/tournament/tournamentSwiss.ts
+++ b/packages/backend/src/tournament/tournamentSwiss.ts
@@ -104,29 +104,21 @@ function pairParticipants(
     }
 
     const [firstParticipant, ...remainingParticipants] = participants;
-    const sortedCandidates = remainingParticipants
-        .map((participant, index) => ({
-            participant,
-            index,
-        }))
-        .sort((left, right) =>
-            Math.abs((left.participant.seed ?? 0) - (firstParticipant.seed ?? 0))
-            - Math.abs((right.participant.seed ?? 0) - (firstParticipant.seed ?? 0))
-            || (left.participant.seed ?? Number.MAX_SAFE_INTEGER) - (right.participant.seed ?? Number.MAX_SAFE_INTEGER));
 
-    for (const candidate of sortedCandidates) {
-        if (playedPairings.has(getPairingKey(firstParticipant.profileId, candidate.participant.profileId))) {
+    for (let index = 0; index < remainingParticipants.length; index += 1) {
+        const candidate = remainingParticipants[index]!;
+        if (playedPairings.has(getPairingKey(firstParticipant.profileId, candidate.profileId))) {
             continue;
         }
 
-        const nextParticipants = remainingParticipants.filter((_, index) => index !== candidate.index);
+        const nextParticipants = remainingParticipants.filter((_, candidateIndex) => candidateIndex !== index);
         const remainingPairings = pairParticipants(nextParticipants, playedPairings);
         if (!remainingPairings) {
             continue;
         }
 
         return [
-            [firstParticipant, candidate.participant],
+            [firstParticipant, candidate],
             ...remainingPairings,
         ];
     }

--- a/packages/frontend/src/components/TournamentEditorCard.spec.tsx
+++ b/packages/frontend/src/components/TournamentEditorCard.spec.tsx
@@ -107,6 +107,85 @@ test(`preserves a zero join timeout when editing an existing tournament`, async 
     await expect.poll(() => submitted?.matchJoinTimeoutMinutes ?? null).toBe(0);
 });
 
+test(`preserves unsaved format changes across equivalent prop rerenders`, async ({ mount }) => {
+    let submitted: CreateTournamentRequest | null = null;
+
+    const component = await mount(
+        <TournamentEditorCardComponent
+            formKey="edit:tournament-1"
+            title="Edit Tournament"
+            description=""
+            defaultRequest={{ ...baseRequest }}
+            submitLabel="Save"
+            submitting={false}
+            onSubmit={(request) => {
+                submitted = request;
+            }}
+        />,
+    );
+
+    await component.getByRole(`button`, { name: `Swiss` }).click();
+
+    await component.update(
+        <TournamentEditorCardComponent
+            formKey="edit:tournament-1"
+            title="Edit Tournament"
+            description=""
+            defaultRequest={{ ...baseRequest }}
+            submitLabel="Save"
+            submitting={false}
+            onSubmit={(request) => {
+                submitted = request;
+            }}
+        />,
+    );
+
+    await component.getByRole(`button`, { name: `Save` }).click();
+
+    await expect.poll(() => submitted?.format ?? null).toBe(`swiss`);
+});
+
+test(`resets form state when the form key changes to a different tournament revision`, async ({ mount }) => {
+    let submitted: CreateTournamentRequest | null = null;
+
+    const component = await mount(
+        <TournamentEditorCardComponent
+            formKey="edit:tournament-1:1"
+            title="Edit Tournament"
+            description=""
+            defaultRequest={{ ...baseRequest }}
+            submitLabel="Save"
+            submitting={false}
+            onSubmit={(request) => {
+                submitted = request;
+            }}
+        />,
+    );
+
+    await component.getByRole(`button`, { name: `Swiss` }).click();
+
+    await component.update(
+        <TournamentEditorCardComponent
+            formKey="edit:tournament-1:2"
+            title="Edit Tournament"
+            description=""
+            defaultRequest={{
+                ...baseRequest,
+                format: `single-elimination`,
+            }}
+            submitLabel="Save"
+            submitting={false}
+            onSubmit={(request) => {
+                submitted = request;
+            }}
+        />,
+    );
+
+    await component.getByRole(`button`, { name: `Save` }).click();
+
+    await expect.poll(() => submitted?.format ?? null).toBe(`single-elimination`);
+});
+
 test(`maps join timeout and extension settings from tournament detail into the edit request`, async () => {
     const { buildCreateTournamentRequestFromDetail, createDefaultTournamentRequest } = await import(`./TournamentEditorCard`);
     const request = buildCreateTournamentRequestFromDetail({

--- a/packages/frontend/src/components/TournamentEditorCard.tsx
+++ b/packages/frontend/src/components/TournamentEditorCard.tsx
@@ -262,7 +262,8 @@ function TournamentEditorCard({
 }: TournamentEditorCardProps) {
     const [f, setF] = useState<TournamentFormState>(() => init(defaultRequest));
 
-    useEffect(() => { setF(init(defaultRequest)); }, [defaultRequest, formKey]);
+    // Only reset when the caller intentionally swaps to a different form payload.
+    useEffect(() => { setF(init(defaultRequest)); }, [formKey]);
 
     const set = <K extends keyof TournamentFormState>(k: K, v: TournamentFormState[K]) =>
         setF((c) => ({ ...c, [k]: v }));

--- a/packages/frontend/src/components/WaitingScreen.spec.tsx
+++ b/packages/frontend/src/components/WaitingScreen.spec.tsx
@@ -39,6 +39,8 @@ function createTournament(overrides: Partial<SessionTournamentInfo> = {}): Sessi
     matchStartedAt: Date.now() - 6 * 60 * 1000,
     leftDisplayName: 'Alpha',
     rightDisplayName: 'Bravo',
+    leftProfileId: 'profile-alpha',
+    rightProfileId: 'profile-bravo',
     ...overrides,
   }
 }
@@ -49,6 +51,7 @@ test('shows a pending extension state instead of tournament timeout actions', as
       sessionId="session-1"
       playerCount={1}
       localPlayerName="Alpha"
+      localProfileId="profile-alpha"
       gameOptions={gameOptions}
       tournament={createTournament({ pendingExtension: true })}
       onInviteFriend={() => { }}

--- a/packages/frontend/src/components/WaitingScreen.spec.tsx
+++ b/packages/frontend/src/components/WaitingScreen.spec.tsx
@@ -36,7 +36,7 @@ function createTournament(overrides: Partial<SessionTournamentInfo> = {}): Sessi
     matchJoinTimeoutMs: 5 * 60 * 1000,
     matchExtensionMs: 5 * 60 * 1000,
     pendingExtension: false,
-    matchStartedAt: Date.now() - 6 * 60 * 1000,
+    matchJoinTimeoutInMs: 0,
     leftDisplayName: 'Alpha',
     rightDisplayName: 'Bravo',
     leftProfileId: 'profile-alpha',

--- a/packages/frontend/src/components/WaitingScreen.spec.tsx
+++ b/packages/frontend/src/components/WaitingScreen.spec.tsx
@@ -1,0 +1,62 @@
+import type { LobbyOptions, SessionTournamentInfo } from '@ih3t/shared'
+import { expect, test } from '@playwright/experimental-ct-react'
+
+import WaitingScreen from './WaitingScreen'
+
+test.use({
+  viewport: {
+    width: 1280,
+    height: 960,
+  },
+})
+
+const gameOptions: LobbyOptions = {
+  visibility: 'private',
+  timeControl: {
+    mode: 'match',
+    mainTimeMs: 5 * 60 * 1000,
+    incrementMs: 5 * 1000,
+  },
+  rated: false,
+  firstPlayer: 'random',
+}
+
+function createTournament(overrides: Partial<SessionTournamentInfo> = {}): SessionTournamentInfo {
+  return {
+    tournamentId: 'tournament-1',
+    tournamentName: 'Spring Major',
+    matchId: 'match-1',
+    bracket: 'winners',
+    round: 1,
+    order: 1,
+    bestOf: 1,
+    currentGameNumber: 1,
+    leftWins: 0,
+    rightWins: 0,
+    matchJoinTimeoutMs: 5 * 60 * 1000,
+    matchExtensionMs: 5 * 60 * 1000,
+    pendingExtension: false,
+    matchStartedAt: Date.now() - 6 * 60 * 1000,
+    leftDisplayName: 'Alpha',
+    rightDisplayName: 'Bravo',
+    ...overrides,
+  }
+}
+
+test('shows a pending extension state instead of tournament timeout actions', async ({ mount }) => {
+  const component = await mount(
+    <WaitingScreen
+      sessionId="session-1"
+      playerCount={1}
+      localPlayerName="Alpha"
+      gameOptions={gameOptions}
+      tournament={createTournament({ pendingExtension: true })}
+      onInviteFriend={() => { }}
+      onCancel={() => { }}
+    />
+  )
+
+  await expect(component.getByText('Extension Pending')).toBeVisible()
+  await expect(component.getByRole('button', { name: /Claim Win/i })).toHaveCount(0)
+  await expect(component.getByRole('button', { name: /Request Extension/i })).toHaveCount(0)
+})

--- a/packages/frontend/src/components/WaitingScreen.tsx
+++ b/packages/frontend/src/components/WaitingScreen.tsx
@@ -1,5 +1,5 @@
 import type { LobbyOptions, MatchClaimWinState, SessionTournamentInfo } from '@ih3t/shared';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
 
 import { useLiveGameStore } from '../liveGameStore';
@@ -61,9 +61,16 @@ function TournamentTimerSection({
     opponentName: string | null
 }) {
     const hasTimeout = tournament.matchJoinTimeoutMs > 0;
-    const joinDeadline = hasTimeout ? tournament.matchStartedAt + tournament.matchJoinTimeoutMs : null;
+    const joinDeadline = useMemo(
+        () => tournament.matchJoinTimeoutInMs !== null ? Date.now() + tournament.matchJoinTimeoutInMs : null,
+        [tournament.matchJoinTimeoutInMs],
+    );
+    const claimDeadline = useMemo(
+        () => claimWinState !== null ? Date.now() + claimWinState.expiresInMs : null,
+        [claimWinState],
+    );
     const joinRemaining = useCountdown(joinDeadline);
-    const claimRemaining = useCountdown(claimWinState?.expiresAt ?? null);
+    const claimRemaining = useCountdown(claimDeadline);
     const [isClaimPending, setIsClaimPending] = useState(false);
     const [isExtensionPending, setIsExtensionPending] = useState(false);
     const extensionMinutes = Math.round(tournament.matchExtensionMs / 60_000);

--- a/packages/frontend/src/components/WaitingScreen.tsx
+++ b/packages/frontend/src/components/WaitingScreen.tsx
@@ -69,6 +69,7 @@ function TournamentTimerSection({
 
     const isTimedOut = hasTimeout && joinRemaining !== null && joinRemaining <= 0;
     const hasActiveClaim = claimWinState !== null;
+    const hasPendingExtension = tournament.pendingExtension;
 
     if (!hasTimeout) {
         return null;
@@ -111,6 +112,21 @@ function TournamentTimerSection({
                 </div>
                 <p className="mt-1 text-xs text-rose-200/70">
                     {opponentName ?? `Opponent`} has {claimSeconds} second{claimSeconds !== 1 ? `s` : ``} to join before the match is forfeited.
+                </p>
+            </div>
+        );
+    }
+
+    if (hasPendingExtension) {
+        return (
+            <div className="mt-4 rounded-2xl border border-amber-300/25 bg-amber-400/10 px-4 py-4 text-center">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-200/80">
+                    Extension Pending
+                </div>
+                <p className="mt-2 text-sm text-amber-100/80">
+                    {isTimedOut
+                        ? `The join timer expired, and an extension request is waiting for organizer review.`
+                        : `An extension request is waiting for organizer review.`}
                 </p>
             </div>
         );

--- a/packages/frontend/src/components/WaitingScreen.tsx
+++ b/packages/frontend/src/components/WaitingScreen.tsx
@@ -11,6 +11,7 @@ type WaitingScreenProps = {
     sessionId: string
     playerCount: number
     localPlayerName: string,
+    localProfileId: string | null,
     gameOptions: LobbyOptions
     tournament: SessionTournamentInfo | null
     onInviteFriend: () => void
@@ -192,6 +193,7 @@ function WaitingScreen({
     sessionId,
     playerCount,
     localPlayerName,
+    localProfileId,
     gameOptions,
     tournament,
     onInviteFriend,
@@ -201,7 +203,7 @@ function WaitingScreen({
     const isTournament = tournament !== null;
     const claimWinState = useLiveGameStore((s) => s.claimWinState);
     const opponentName = isTournament
-        ? (tournament.leftDisplayName === localPlayerName ? tournament.rightDisplayName : tournament.leftDisplayName)
+        ? (localProfileId === tournament.leftProfileId ? tournament.rightDisplayName : tournament.leftDisplayName)
         : null;
     const showOfflinePlayButton = !isTournament && gameOptions.visibility === `public` && playerCount < 2 && Boolean(onPlayOffline);
 

--- a/packages/frontend/src/components/game-screen/GameScreenHud.spec.tsx
+++ b/packages/frontend/src/components/game-screen/GameScreenHud.spec.tsx
@@ -94,6 +94,8 @@ test('hides draw actions for tournament matches', async ({ mount }) => {
             matchStartedAt: 1_700_000_000_000,
             leftDisplayName: 'Alpha',
             rightDisplayName: 'Bravo',
+            leftProfileId: 'profile-alpha',
+            rightProfileId: 'profile-bravo',
           },
         })}
       />

--- a/packages/frontend/src/components/game-screen/GameScreenHud.spec.tsx
+++ b/packages/frontend/src/components/game-screen/GameScreenHud.spec.tsx
@@ -91,7 +91,7 @@ test('hides draw actions for tournament matches', async ({ mount }) => {
             matchJoinTimeoutMs: 300000,
             matchExtensionMs: 300000,
             pendingExtension: false,
-            matchStartedAt: 1_700_000_000_000,
+            matchJoinTimeoutInMs: 300000,
             leftDisplayName: 'Alpha',
             rightDisplayName: 'Bravo',
             leftProfileId: 'profile-alpha',

--- a/packages/frontend/src/components/game-screen/GameScreenHud.spec.tsx
+++ b/packages/frontend/src/components/game-screen/GameScreenHud.spec.tsx
@@ -90,6 +90,7 @@ test('hides draw actions for tournament matches', async ({ mount }) => {
             rightWins: 0,
             matchJoinTimeoutMs: 300000,
             matchExtensionMs: 300000,
+            pendingExtension: false,
             matchStartedAt: 1_700_000_000_000,
             leftDisplayName: 'Alpha',
             rightDisplayName: 'Bravo',

--- a/packages/frontend/src/liveGameClient.ts
+++ b/packages/frontend/src/liveGameClient.ts
@@ -303,7 +303,12 @@ export function startLiveGameClient() {
          * so the match card updates immediately instead of waiting for reconciliation. */
         if (data.session.state?.status === `finished`) {
             const store = useLiveGameStore.getState();
-            if (store.session?.tournament || data.session.tournament || watchedTile?.session?.tournament) {
+            const tournamentId = store.session?.tournament?.tournamentId
+                ?? data.session.tournament?.tournamentId
+                ?? watchedTile?.session?.tournament?.tournamentId
+                ?? null;
+            if (tournamentId) {
+                void queryClient.invalidateQueries({ queryKey: queryKeys.tournament(tournamentId) });
                 void queryClient.invalidateQueries({ queryKey: queryKeys.tournaments });
             }
         }

--- a/packages/frontend/src/query/devAuthClient.ts
+++ b/packages/frontend/src/query/devAuthClient.ts
@@ -110,3 +110,17 @@ export async function createQuickSealBotTournament() {
 
     return response.tournament;
 }
+
+export async function createQuickSealBot16Tournament(format: `swiss` | `single-elimination` | `double-elimination`) {
+    const response = await fetchJson<DevQuickBotTournamentResponse>(`/api/dev/tournaments/quick-seal-bot-16/${encodeURIComponent(format)}`, {
+        method: `POST`,
+    });
+
+    queryClient.setQueryData(queryKeys.tournament(response.tournament.id), response.tournament);
+    await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.tournaments }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.ownTournaments }),
+    ]);
+
+    return response.tournament;
+}

--- a/packages/frontend/src/routes/SessionRoute.tsx
+++ b/packages/frontend/src/routes/SessionRoute.tsx
@@ -467,7 +467,9 @@ function SessionRoute() {
                 </div>
             );
         } else {
-            const localPlayerName = session.players.find(player => player.id === session.localParticipantId)?.displayName ?? account?.user?.username ?? `unknown`;
+            const localPlayer = session.players.find(player => player.id === session.localParticipantId);
+            const localPlayerName = localPlayer?.displayName ?? account?.user?.username ?? `unknown`;
+            const localProfileId = localPlayer?.profileId ?? account?.user?.id ?? null;
 
             targetScreen = (
                 <WaitingScreen
@@ -476,6 +478,7 @@ function SessionRoute() {
 
                     playerCount={session.players.length}
                     localPlayerName={localPlayerName}
+                    localProfileId={localProfileId}
                     tournament={session.tournament}
                     onInviteFriend={() => void inviteFriend()}
                     onPlayOffline={session.gameOptions.visibility === `public` ? leaveSessionAndOpenOfflineBotGame : undefined}

--- a/packages/frontend/src/routes/TournamentBracketRoute.tsx
+++ b/packages/frontend/src/routes/TournamentBracketRoute.tsx
@@ -24,27 +24,35 @@ function MatchNode({ match, onSpectate }: { match: TournamentMatch; onSpectate: 
         }
     };
 
-    const slot = (s: TournamentMatch[`slots`][number], wins: number, isWinner: boolean, side: `top` | `bottom`) => (
-        <div className={`flex items-center gap-2 px-2.5 py-1.5 ${
-            side === `top` ? `rounded-t` : `rounded-b`
-        } ${isWinner ? `bg-emerald-400/8` : s.isBye ? `bg-white/[0.015]` : `bg-white/[0.025]`}`}>
-            <span className="w-4 shrink-0 text-center text-[9px] font-bold tabular-nums text-slate-600">
-                {s.seed ?? ``}
-            </span>
-            <span className={`min-w-0 flex-1 truncate text-[11px] ${
-                s.isBye ? `italic text-slate-600`
-                    : isWinner ? `font-bold text-emerald-200`
-                        : s.profileId ? `font-medium text-slate-200` : `text-slate-600`
-            }`}>
-                {s.displayName ?? (s.isBye ? `BYE` : `TBD`)}
-            </span>
-            {!s.isBye && s.profileId && (
-                <span className={`shrink-0 text-[11px] font-bold tabular-nums ${isWinner ? `text-emerald-300` : `text-slate-500`}`}>
-                    {wins}
+    const slot = (s: TournamentMatch[`slots`][number], wins: number, isWinner: boolean, side: `top` | `bottom`) => {
+        const isTbd = !s.profileId && !s.isBye;
+        const source = isTbd && s.source && s.source.type !== `seed` ? s.source : null;
+        const sourceLabel = source
+            ? `${source.type === `winner` ? `W` : `L`} of M${source.matchId.split(`-`).at(-1)}`
+            : null;
+
+        return (
+            <div className={`flex items-center gap-2 px-2.5 py-1.5 ${
+                side === `top` ? `rounded-t` : `rounded-b`
+            } ${isWinner ? `bg-emerald-400/8` : s.isBye ? `bg-white/[0.015]` : `bg-white/[0.025]`}`}>
+                <span className="w-4 shrink-0 text-center text-[9px] font-bold tabular-nums text-slate-600">
+                    {s.seed ?? ``}
                 </span>
-            )}
-        </div>
-    );
+                <span className={`min-w-0 flex-1 truncate text-[11px] ${
+                    s.isBye ? `italic text-slate-600`
+                        : isWinner ? `font-bold text-emerald-200`
+                            : s.profileId ? `font-medium text-slate-200` : `text-slate-600`
+                }`}>
+                    {s.displayName ?? (s.isBye ? `BYE` : sourceLabel ?? `TBD`)}
+                </span>
+                {!s.isBye && s.profileId && (
+                    <span className={`shrink-0 text-[11px] font-bold tabular-nums ${isWinner ? `text-emerald-300` : `text-slate-500`}`}>
+                        {wins}
+                    </span>
+                )}
+            </div>
+        );
+    };
 
     return (
         <div

--- a/packages/frontend/src/routes/TournamentBracketRoute.tsx
+++ b/packages/frontend/src/routes/TournamentBracketRoute.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { TournamentMatch } from '@ih3t/shared';
+import type { TournamentFormat, TournamentMatch } from '@ih3t/shared';
 import { Link, useNavigate, useParams } from 'react-router';
 
 import PageMetadata, { DEFAULT_PAGE_TITLE } from '../components/PageMetadata';
@@ -107,6 +107,35 @@ function ScaledMatchNode({
             </div>
         </div>
     );
+}
+
+function getTournamentFormatLabel(format: TournamentFormat): string {
+    switch (format) {
+        case `single-elimination`:
+            return `Single Elimination`;
+        case `double-elimination`:
+            return `Double Elimination`;
+        case `swiss`:
+            return `Swiss`;
+    }
+}
+
+function groupBracketRounds(matches: TournamentMatch[], bracket: TournamentMatch[`bracket`]) {
+    const rounds = new Map<number, TournamentMatch[]>();
+
+    for (const match of matches) {
+        if (match.bracket !== bracket) {
+            continue;
+        }
+
+        const existingMatches = rounds.get(match.round) ?? [];
+        existingMatches.push(match);
+        rounds.set(match.round, existingMatches);
+    }
+
+    return Array.from(rounds.entries())
+        .sort(([left], [right]) => left - right)
+        .map(([round, roundMatches]) => ({ round, matches: roundMatches }));
 }
 
 function BracketConnectors({
@@ -264,6 +293,35 @@ function SwissView({
 
 /* ── Double Elimination view ───────────────────────── */
 
+function SingleElimView({
+    matches,
+    onSpectate,
+    scale,
+}: {
+    matches: TournamentMatch[]
+    onSpectate: (sid: string) => void
+    scale: number
+}) {
+    const winnersRounds = groupBracketRounds(matches, `winners`);
+    const thirdPlaceMatches = matches
+        .filter((match) => match.bracket === `third-place`)
+        .sort((left, right) => left.order - right.order);
+
+    return (
+        <div className="space-y-2">
+            <BracketSection label="Championship Bracket" rounds={winnersRounds} onSpectate={onSpectate} scale={scale} />
+            {thirdPlaceMatches.length > 0 && (
+                <BracketSection
+                    label="Third Place"
+                    rounds={[{ round: 1, matches: thirdPlaceMatches }]}
+                    onSpectate={onSpectate}
+                    scale={scale}
+                />
+            )}
+        </div>
+    );
+}
+
 function DoubleElimView({
     matches,
     onSpectate,
@@ -273,31 +331,16 @@ function DoubleElimView({
     onSpectate: (sid: string) => void
     scale: number
 }) {
-    const winners = new Map<number, TournamentMatch[]>();
-    const losers = new Map<number, TournamentMatch[]>();
     const grandFinal: TournamentMatch[] = [];
     const grandFinalReset: TournamentMatch[] = [];
 
     for (const m of matches) {
-        if (m.bracket === `winners`) {
-            const arr = winners.get(m.round) ?? [];
-            arr.push(m);
-            winners.set(m.round, arr);
-        } else if (m.bracket === `losers`) {
-            const arr = losers.get(m.round) ?? [];
-            arr.push(m);
-            losers.set(m.round, arr);
-        } else if (m.bracket === `grand-final`) {
+        if (m.bracket === `grand-final`) {
             grandFinal.push(m);
         } else if (m.bracket === `grand-final-reset`) {
             grandFinalReset.push(m);
         }
     }
-
-    const toRounds = (map: Map<number, TournamentMatch[]>) =>
-        Array.from(map.entries())
-            .sort(([a], [b]) => a - b)
-            .map(([round, ms]) => ({ round, matches: ms }));
 
     const gfRounds: { round: number; matches: TournamentMatch[] }[] = [];
     if (grandFinal.length > 0) gfRounds.push({ round: 1, matches: grandFinal });
@@ -305,8 +348,8 @@ function DoubleElimView({
 
     return (
         <div className="space-y-2">
-            <BracketSection label="Winners Bracket" rounds={toRounds(winners)} onSpectate={onSpectate} scale={scale} />
-            <BracketSection label="Losers Bracket" rounds={toRounds(losers)} onSpectate={onSpectate} scale={scale} />
+            <BracketSection label="Winners Bracket" rounds={groupBracketRounds(matches, `winners`)} onSpectate={onSpectate} scale={scale} />
+            <BracketSection label="Losers Bracket" rounds={groupBracketRounds(matches, `losers`)} onSpectate={onSpectate} scale={scale} />
             {gfRounds.length > 0 && <BracketSection label="Grand Final" rounds={gfRounds} onSpectate={onSpectate} scale={scale} />}
         </div>
     );
@@ -345,7 +388,7 @@ function TournamentBracketRoute() {
 
                         {t && (
                             <div className="ml-auto flex items-center gap-2 text-[10px] text-slate-500">
-                                <span>{t.format === `swiss` ? `Swiss` : `Double Elimination`}</span>
+                                <span>{getTournamentFormatLabel(t.format)}</span>
                                 <span>·</span>
                                 <span>{t.checkedInCount}/{t.maxPlayers} players</span>
                                 <span>·</span>
@@ -404,6 +447,8 @@ function TournamentBracketRoute() {
                             </div>
                         ) : t.format === `swiss` ? (
                             <SwissView matches={t.matches} onSpectate={handleSpectate} scale={scale} />
+                        ) : t.format === `single-elimination` ? (
+                            <SingleElimView matches={t.matches} onSpectate={handleSpectate} scale={scale} />
                         ) : (
                             <DoubleElimView matches={t.matches} onSpectate={handleSpectate} scale={scale} />
                         )}

--- a/packages/frontend/src/routes/TournamentBracketRoute.tsx
+++ b/packages/frontend/src/routes/TournamentBracketRoute.tsx
@@ -15,7 +15,7 @@ const STATE_COLORS: Record<string, { dot: string; border: string }> = {
     completed: { dot: `bg-emerald-400`, border: `border-emerald-400/15` },
 };
 
-function MatchNode({ match, onSpectate }: { match: TournamentMatch; onSpectate: (sid: string) => void }) {
+function MatchNode({ match, allMatches, onSpectate }: { match: TournamentMatch; allMatches: TournamentMatch[]; onSpectate: (sid: string) => void }) {
     const { dot, border } = STATE_COLORS[match.state] ?? STATE_COLORS.pending!;
     const isLive = match.state === `in-progress` && match.sessionId;
     const handleSpectate = () => {
@@ -27,8 +27,12 @@ function MatchNode({ match, onSpectate }: { match: TournamentMatch; onSpectate: 
     const slot = (s: TournamentMatch[`slots`][number], wins: number, isWinner: boolean, side: `top` | `bottom`) => {
         const isTbd = !s.profileId && !s.isBye;
         const source = isTbd && s.source && s.source.type !== `seed` ? s.source : null;
-        const sourceLabel = source
-            ? `${source.type === `winner` ? `W` : `L`} of M${source.matchId.split(`-`).at(-1)}`
+        const sourceRecord = source ? allMatches.find((entry) => entry.id === source.matchId) ?? null : null;
+        const bracketSuffix = sourceRecord?.bracket === `losers` ? ` (LB)`
+            : sourceRecord?.bracket === `grand-final` ? ` (GF)`
+                : sourceRecord?.bracket === `grand-final-reset` ? ` (GF Reset)` : ``;
+        const sourceLabel = source && sourceRecord
+            ? `${source.type === `winner` ? `W` : `L`} of R${sourceRecord.round}M${sourceRecord.order}${bracketSuffix}`
             : null;
 
         return (
@@ -102,17 +106,19 @@ function getMatchY(index: number, count: number, totalHeight: number, matchHeigh
 
 function ScaledMatchNode({
     match,
+    allMatches,
     onSpectate,
     scale,
 }: {
     match: TournamentMatch
+    allMatches: TournamentMatch[]
     onSpectate: (sid: string) => void
     scale: number
 }) {
     return (
         <div className="relative shrink-0" style={{ width: MATCH_W * scale, height: MATCH_H * scale }}>
             <div className="origin-top-left" style={{ width: MATCH_W, transform: `scale(${scale})` }}>
-                <MatchNode match={match} onSpectate={onSpectate} />
+                <MatchNode match={match} allMatches={allMatches} onSpectate={onSpectate} />
             </div>
         </div>
     );
@@ -200,9 +206,10 @@ function BracketConnectors({
 
 /* ── Bracket section with connectors ───────────────── */
 
-function BracketSection({ label, rounds, onSpectate, scale }: {
+function BracketSection({ label, rounds, allMatches, onSpectate, scale }: {
     label: string
     rounds: { round: number; matches: TournamentMatch[] }[]
+    allMatches: TournamentMatch[]
     onSpectate: (sid: string) => void
     scale: number
 }) {
@@ -250,7 +257,7 @@ function BracketSection({ label, rounds, onSpectate, scale }: {
                                         top: getMatchY(idx, r.matches.length, totalHeight, matchHeight),
                                     }}
                                 >
-                                    <ScaledMatchNode match={m} onSpectate={onSpectate} scale={scale} />
+                                    <ScaledMatchNode match={m} allMatches={allMatches} onSpectate={onSpectate} scale={scale} />
                                 </div>
                             ))}
                         </div>
@@ -287,7 +294,7 @@ function SwissView({
                     <div className="mb-2 text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500">Round {round}</div>
                     <div className="flex flex-wrap" style={{ gap }}>
                         {rMatches.sort((a, b) => a.order - b.order).map((m) => (
-                            <ScaledMatchNode key={m.id} match={m} onSpectate={onSpectate} scale={scale} />
+                            <ScaledMatchNode key={m.id} match={m} allMatches={matches} onSpectate={onSpectate} scale={scale} />
                         ))}
                     </div>
                 </div>
@@ -314,11 +321,12 @@ function SingleElimView({
 
     return (
         <div className="space-y-2">
-            <BracketSection label="Championship Bracket" rounds={winnersRounds} onSpectate={onSpectate} scale={scale} />
+            <BracketSection label="Championship Bracket" rounds={winnersRounds} allMatches={matches} onSpectate={onSpectate} scale={scale} />
             {thirdPlaceMatches.length > 0 && (
                 <BracketSection
                     label="Third Place"
                     rounds={[{ round: 1, matches: thirdPlaceMatches }]}
+                    allMatches={matches}
                     onSpectate={onSpectate}
                     scale={scale}
                 />
@@ -353,9 +361,9 @@ function DoubleElimView({
 
     return (
         <div className="space-y-2">
-            <BracketSection label="Winners Bracket" rounds={groupBracketRounds(matches, `winners`)} onSpectate={onSpectate} scale={scale} />
-            <BracketSection label="Losers Bracket" rounds={groupBracketRounds(matches, `losers`)} onSpectate={onSpectate} scale={scale} />
-            {gfRounds.length > 0 && <BracketSection label="Grand Final" rounds={gfRounds} onSpectate={onSpectate} scale={scale} />}
+            <BracketSection label="Winners Bracket" rounds={groupBracketRounds(matches, `winners`)} allMatches={matches} onSpectate={onSpectate} scale={scale} />
+            <BracketSection label="Losers Bracket" rounds={groupBracketRounds(matches, `losers`)} allMatches={matches} onSpectate={onSpectate} scale={scale} />
+            {gfRounds.length > 0 && <BracketSection label="Grand Final" rounds={gfRounds} allMatches={matches} onSpectate={onSpectate} scale={scale} />}
         </div>
     );
 }

--- a/packages/frontend/src/routes/TournamentBracketRoute.tsx
+++ b/packages/frontend/src/routes/TournamentBracketRoute.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate, useParams } from 'react-router';
 
 import PageMetadata, { DEFAULT_PAGE_TITLE } from '../components/PageMetadata';
 import { useQueryTournament } from '../query/tournamentClient';
+import { getBracketConnectorEdges } from '../utils/tournamentBracketConnectors';
 
 /* ── Match node ─────────────────────────────────────── */
 
@@ -152,34 +153,30 @@ function BracketConnectors({
     columnGap: number
 }) {
     const paths: React.ReactNode[] = [];
+    const sortedRounds = rounds.map((round) => ({
+        round: round.round,
+        matches: [...round.matches].sort((left, right) => left.order - right.order),
+    }));
+    const connectorEdges = getBracketConnectorEdges(sortedRounds);
 
-    for (let i = 0; i < rounds.length - 1; i++) {
-        const curr = rounds[i]!;
-        const next = rounds[i + 1]!;
-        const x1 = i * (matchWidth + columnGap) + matchWidth;
-        const x2 = (i + 1) * (matchWidth + columnGap);
+    for (const edge of connectorEdges) {
+        const sourceRound = sortedRounds[edge.sourceRoundIndex]!;
+        const targetRound = sortedRounds[edge.targetRoundIndex]!;
+        const x1 = edge.sourceRoundIndex * (matchWidth + columnGap) + matchWidth;
+        const x2 = edge.targetRoundIndex * (matchWidth + columnGap);
         const midX = (x1 + x2) / 2;
+        const sourceY = getMatchY(edge.sourceMatchIndex, sourceRound.matches.length, totalHeight, matchHeight) + matchHeight / 2;
+        const targetY = getMatchY(edge.targetMatchIndex, targetRound.matches.length, totalHeight, matchHeight) + matchHeight / 2;
 
-        for (let j = 0; j < next.matches.length; j++) {
-            const targetY = getMatchY(j, next.matches.length, totalHeight, matchHeight) + matchHeight / 2;
-
-            // Each next match is fed by 2 matches from current round (standard bracket)
-            const sourceIndices = [j * 2, j * 2 + 1];
-            for (const si of sourceIndices) {
-                if (si >= curr.matches.length) continue;
-                const sourceY = getMatchY(si, curr.matches.length, totalHeight, matchHeight) + matchHeight / 2;
-
-                paths.push(
-                    <path
-                        key={`${i}-${si}-${j}`}
-                        d={`M ${x1} ${sourceY} H ${midX} V ${targetY} H ${x2}`}
-                        fill="none"
-                        stroke="rgba(255,255,255,0.06)"
-                        strokeWidth={1.5}
-                    />,
-                );
-            }
-        }
+        paths.push(
+            <path
+                key={`${edge.sourceRoundIndex}-${edge.sourceMatchIndex}-${edge.targetRoundIndex}-${edge.targetMatchIndex}`}
+                d={`M ${x1} ${sourceY} H ${midX} V ${targetY} H ${x2}`}
+                fill="none"
+                stroke="rgba(255,255,255,0.06)"
+                strokeWidth={1.5}
+            />,
+        );
     }
 
     return (

--- a/packages/frontend/src/routes/TournamentListRoute.tsx
+++ b/packages/frontend/src/routes/TournamentListRoute.tsx
@@ -7,7 +7,7 @@ import PageCorpus from '../components/PageCorpus';
 import PageMetadata, { DEFAULT_PAGE_TITLE } from '../components/PageMetadata';
 import TournamentEditorCard, { createDefaultTournamentRequest } from '../components/TournamentEditorCard';
 import { useQueryAccount } from '../query/accountClient';
-import { createQuickSealBotTournament, seedTournamentWithDevUsers } from '../query/devAuthClient';
+import { createQuickSealBot16Tournament, createQuickSealBotTournament, seedTournamentWithDevUsers } from '../query/devAuthClient';
 import {
     createTournament,
     startTournament,
@@ -280,6 +280,7 @@ function TournamentListRoute() {
     const [showCreateForm, setShowCreateForm] = useState(false);
     const [quickCreating, setQuickCreating] = useState(false);
     const [quickSealBotCreating, setQuickSealBotCreating] = useState(false);
+    const [quickSealBot16Creating, setQuickSealBot16Creating] = useState<`swiss` | `single-elimination` | `double-elimination` | null>(null);
 
     const acct = acctQ.data?.user ?? null;
     const data = tQ.data;
@@ -351,6 +352,22 @@ function TournamentListRoute() {
             toast.error(err instanceof Error ? err.message : `Quick Seal Bot tournament failed.`, { toastId: `quick-seal-bot-err` });
         } finally {
             setQuickSealBotCreating(false);
+        }
+    };
+
+    const handleQuickSealBot16Create = async (format: `swiss` | `single-elimination` | `double-elimination`) => {
+        if (!import.meta.env.DEV) return;
+
+        try {
+            setQuickSealBot16Creating(format);
+            const tournament = await createQuickSealBot16Tournament(format);
+            const label = format === `swiss` ? `Swiss` : format === `single-elimination` ? `Single Elim` : `Double Elim`;
+            toast.success(`16-player ${label} Seal Bot tournament created.`, { toastId: `quick-seal-bot-16` });
+            void nav(`/tournaments/${tournament.id}`);
+        } catch (err: unknown) {
+            toast.error(err instanceof Error ? err.message : `Quick Seal Bot tournament failed.`, { toastId: `quick-seal-bot-16-err` });
+        } finally {
+            setQuickSealBot16Creating(null);
         }
     };
 
@@ -431,13 +448,40 @@ function TournamentListRoute() {
 
                         {import.meta.env.DEV && acct && (
                             <div className="grid gap-2">
+                                <div className="text-[9px] font-bold uppercase tracking-[0.15em] text-slate-600">16-Player Seal Bot Tests</div>
+                                <button
+                                    type="button"
+                                    onClick={() => void handleQuickSealBot16Create(`swiss`)}
+                                    disabled={quickSealBot16Creating !== null}
+                                    className="w-full rounded-lg border border-dashed border-violet-400/30 bg-violet-400/6 px-3 py-2 text-[11px] font-semibold text-violet-300 transition hover:bg-violet-400/12 disabled:opacity-40"
+                                >
+                                    {quickSealBot16Creating === `swiss` ? `Creating...` : `Swiss 16P — Seal Bots`}
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => void handleQuickSealBot16Create(`single-elimination`)}
+                                    disabled={quickSealBot16Creating !== null}
+                                    className="w-full rounded-lg border border-dashed border-teal-400/30 bg-teal-400/6 px-3 py-2 text-[11px] font-semibold text-teal-300 transition hover:bg-teal-400/12 disabled:opacity-40"
+                                >
+                                    {quickSealBot16Creating === `single-elimination` ? `Creating...` : `Single Elim 16P — Seal Bots`}
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => void handleQuickSealBot16Create(`double-elimination`)}
+                                    disabled={quickSealBot16Creating !== null}
+                                    className="w-full rounded-lg border border-dashed border-sky-400/30 bg-sky-400/6 px-3 py-2 text-[11px] font-semibold text-sky-300 transition hover:bg-sky-400/12 disabled:opacity-40"
+                                >
+                                    {quickSealBot16Creating === `double-elimination` ? `Creating...` : `Double Elim 16P — Seal Bots`}
+                                </button>
+
+                                <div className="text-[9px] font-bold uppercase tracking-[0.15em] text-slate-600 mt-1">Other</div>
                                 <button
                                     type="button"
                                     onClick={() => void handleQuickSealBotCreate()}
                                     disabled={quickSealBotCreating}
                                     className="w-full rounded-lg border border-dashed border-sky-300/30 bg-sky-300/6 px-3 py-2 text-[11px] font-semibold text-sky-200 transition hover:bg-sky-300/12 disabled:opacity-40"
                                 >
-                                    {quickSealBotCreating ? `Creating...` : `Quick Create 8-Player Seal Bot Tournament`}
+                                    {quickSealBotCreating ? `Creating...` : `Double Elim 8P — Seal Bots`}
                                 </button>
 
                                 <button

--- a/packages/frontend/src/routes/TournamentRoute.tsx
+++ b/packages/frontend/src/routes/TournamentRoute.tsx
@@ -887,10 +887,8 @@ function MatchCard({ match, canManage, viewerProfileId, tournamentStatus, timeou
                     {s.displayName ?? `TBD`}
                     {canNavigate && <span className="text-[9px] text-slate-600">
                         {sourceMatch.type === `winner` ? `W` : `L`}
-                        {` `}
-                        of
-                        {` `}
-                        {sourceMatch.matchId.replace(`match-`, ``)}
+                        {` of M`}
+                        {sourceMatch.matchId.split(`-`).at(-1)}
                                     </span>}
                 </span>
 

--- a/packages/frontend/src/routes/TournamentRoute.tsx
+++ b/packages/frontend/src/routes/TournamentRoute.tsx
@@ -34,6 +34,8 @@ import {
     withdrawFromTournament,
 } from '../query/tournamentClient';
 import { formatDateTime, useIntlFormatProvider } from '../utils/dateTime';
+import { getTournamentMatchSessionAccess } from '../utils/tournamentMatchSessionAccess';
+import { getRoundDelayCountdownState } from '../utils/tournamentRoundDelay';
 
 /* ── Modal overlay ──────────────────────────────────── */
 
@@ -147,25 +149,10 @@ function RoundDelayCountdown({ tournament }: { tournament: TournamentDetail }) {
     }, [tournament.roundDelayMinutes]);
 
     if (tournament.roundDelayMinutes <= 0 || tournament.status !== `live`) return null;
+    const countdown = getRoundDelayCountdownState(tournament);
+    if (!countdown) return null;
 
-    // Find the next round that's pending but whose previous round is complete
-    const pendingMatches = tournament.matches.filter((m) => m.state === `pending`);
-    if (pendingMatches.length === 0) return null;
-
-    const nextRound = Math.min(...pendingMatches.map((m) => m.round));
-    const bracket = pendingMatches.find((m) => m.round === nextRound)?.bracket;
-    if (!bracket) return null;
-
-    const prevRoundMatches = tournament.matches.filter((m) => m.bracket === bracket && m.round === nextRound - 1);
-    if (prevRoundMatches.length === 0) return null;
-
-    const allPrevCompleted = prevRoundMatches.every((m) => m.state === `completed`);
-    if (!allPrevCompleted) return null;
-
-    const latestResolved = Math.max(...prevRoundMatches.map((m) => m.resolvedAt ?? 0));
-    const readyAt = latestResolved + tournament.roundDelayMinutes * 60_000;
-    const remaining = Math.max(0, readyAt - Date.now());
-    if (remaining <= 0) return null;
+    const remaining = countdown.remainingMs;
 
     const mins = Math.floor(remaining / 60_000);
     const secs = Math.floor((remaining % 60_000) / 1000);
@@ -867,8 +854,8 @@ function useCountdown(deadlineMs: number | null) {
 
 /* ── Match card ─────────────────────────────────────── */
 
-function MatchCard({ match, canManage, viewerProfileId, timeoutAt, extensionMinutes, pendingExtension, claimWinExpiresAt, onOpen, onWalkover, onReopen, onRequestExtension, onResolveExtension }: {
-    match: TournamentMatch; canManage: boolean; viewerProfileId: string | null
+function MatchCard({ match, canManage, viewerProfileId, tournamentStatus, timeoutAt, extensionMinutes, pendingExtension, claimWinExpiresAt, onOpen, onWalkover, onReopen, onRequestExtension, onResolveExtension }: {
+    match: TournamentMatch; canManage: boolean; viewerProfileId: string | null; tournamentStatus: TournamentDetail[`status`]
     timeoutAt: number | null; extensionMinutes: number; pendingExtension: TournamentExtensionRequest | null; claimWinExpiresAt: number | null
     onOpen: (sid: string) => void; onWalkover: (mid: string, pid: string) => void; onReopen: (mid: string) => void
     onRequestExtension: (mid: string) => void; onResolveExtension: (eid: string, approve: boolean) => void
@@ -877,9 +864,7 @@ function MatchCard({ match, canManage, viewerProfileId, timeoutAt, extensionMinu
     const claimCountdown = useCountdown(claimWinExpiresAt);
     const timedOut = countdown?.expired ?? false;
     const stateColor = match.state === `completed` ? `emerald` as const : match.state === `in-progress` ? `sky` as const : match.state === `ready` ? `amber` as const : `default` as const;
-    const isParticipant = Boolean(viewerProfileId && match.slots.some((s) => s.profileId === viewerProfileId));
-    const canJoin = isParticipant && match.sessionId && (match.state === `ready` || match.state === `in-progress`);
-    const canSpectate = !isParticipant && match.sessionId && match.state === `in-progress` && match.startedAt !== null;
+    const { isParticipant, canJoin, canSpectate } = getTournamentMatchSessionAccess(tournamentStatus, match, viewerProfileId);
     const isInProgress = match.state === `in-progress`;
 
     const slot = (s: TournamentMatch[`slots`][number], wins: number, isW: boolean) => {
@@ -1449,6 +1434,7 @@ function TournamentRoute() {
                                                         <MatchCard
                                                             key={m.id} match={m} canManage={t.viewer.canManage}
                                                             viewerProfileId={acct?.id ?? null}
+                                                            tournamentStatus={t.status}
                                                             timeoutAt={t.matchJoinTimeoutMinutes > 0 && m.waitingForPlayers && m.startedAt !== null ? m.startedAt + t.matchJoinTimeoutMinutes * 60_000 : null}
                                                             extensionMinutes={t.matchExtensionMinutes}
                                                             pendingExtension={t.extensionRequests.find((r) => r.matchId === m.id && (r.gameNumber ?? 1) === m.currentGameNumber && r.status === `pending`) ?? null}

--- a/packages/frontend/src/routes/TournamentRoute.tsx
+++ b/packages/frontend/src/routes/TournamentRoute.tsx
@@ -214,9 +214,9 @@ function sortParticipants(
     return sorted;
 }
 
-function ParticipantList({ participants, standings, canManage, isLive, viewerProfileId, tournamentId, tournamentStatus, onRemove, onSwapSelect, swapTarget }: {
+function ParticipantList({ participants, standings, canManage, isLive, viewerProfileId, tournamentId, tournamentStatus, tournamentStartedAt, onRemove, onSwapSelect, swapTarget }: {
     participants: TournamentParticipant[]; standings: TournamentStanding[]; canManage: boolean; isLive: boolean; viewerProfileId: string | null
-    tournamentId: string; tournamentStatus: string
+    tournamentId: string; tournamentStatus: string; tournamentStartedAt: number | null
     onRemove: (id: string) => void; onSwapSelect: (id: string | null) => void; swapTarget: string | null
 }) {
     const standMap = new Map(standings.map((s) => [s.profileId, s]));
@@ -230,11 +230,14 @@ function ParticipantList({ participants, standings, canManage, isLive, viewerPro
     const isPreStart = tournamentStatus === `registration-open` || tournamentStatus === `check-in-open`;
     const canSeed = canManage && isPreStart;
 
+    const isPreStartDrop = (p: TournamentParticipant) =>
+        p.status === `dropped` && p.removedAt !== null && (tournamentStartedAt === null || p.removedAt < tournamentStartedAt);
+
     const sorted = sortParticipants(participants, seedMode ? `status` : sortMode, standMap);
     const active = sorted.filter((p) => p.status !== `removed` && p.status !== `dropped` && p.status !== `waitlisted`);
     const waitlisted = sorted.filter((p) => p.status === `waitlisted`);
-    const removed = sorted.filter((p) => p.status === `removed`);
-    const dqd = sorted.filter((p) => p.status === `dropped`);
+    const removed = sorted.filter((p) => p.status === `removed` || isPreStartDrop(p));
+    const dqd = sorted.filter((p) => p.status === `dropped` && !isPreStartDrop(p));
     const visible = [...active, ...dqd, ...waitlisted];
 
     // Initialize seed order from active participants when entering seed mode
@@ -1507,7 +1510,7 @@ function TournamentRoute() {
                                         participants={t.participants} standings={t.standings}
                                         canManage={t.viewer.canManage} isLive={t.status === `live`}
                                         viewerProfileId={acct?.id ?? null}
-                                        tournamentId={t.id} tournamentStatus={t.status}
+                                        tournamentId={t.id} tournamentStatus={t.status} tournamentStartedAt={t.startedAt}
                                         onRemove={(pid) => void run(() => removeTournamentParticipant(t.id, pid), t.status === `live` ? `Disqualified.` : `Removed.`)}
                                         onSwapSelect={setSwapTarget} swapTarget={swapTarget}
                                     />

--- a/packages/frontend/src/routes/TournamentRoute.tsx
+++ b/packages/frontend/src/routes/TournamentRoute.tsx
@@ -877,7 +877,7 @@ function MatchCard({ match, canManage, viewerProfileId, timeoutAt, extensionMinu
     const timedOut = countdown?.expired ?? false;
     const stateColor = match.state === `completed` ? `emerald` as const : match.state === `in-progress` ? `sky` as const : match.state === `ready` ? `amber` as const : `default` as const;
     const isParticipant = Boolean(viewerProfileId && match.slots.some((s) => s.profileId === viewerProfileId));
-    const canJoin = isParticipant && match.sessionId && (match.state === `ready` || match.state === `in-progress`) && !timedOut;
+    const canJoin = isParticipant && match.sessionId && (match.state === `ready` || match.state === `in-progress`);
     const canSpectate = !isParticipant && match.sessionId && match.state === `in-progress` && match.startedAt !== null;
     const isInProgress = match.state === `in-progress`;
 
@@ -1062,12 +1062,20 @@ function MatchCard({ match, canManage, viewerProfileId, timeoutAt, extensionMinu
 
             {match.state === `completed` && match.gameIds.length > 0 && (
                 <div className="mt-1.5 flex items-center gap-1.5">
-                    <Link
-                        to={`/games/${match.gameIds[match.gameIds.length - 1]}`}
-                        className="rounded bg-white/6 px-2 py-0.5 text-[9px] text-slate-400 transition hover:text-white"
-                    >
-                        Review
-                    </Link>
+                    {match.gameIds.length === 1 && (
+                        <Link
+                            to={`/games/${match.gameIds[0]}`}
+                            className="rounded bg-white/6 px-2 py-0.5 text-[9px] text-slate-400 transition hover:text-white"
+                        >
+                            Review
+                        </Link>
+                    )}
+
+                    {match.gameIds.length > 1 && (
+                        <span className="text-[9px] font-semibold text-slate-500">
+                            Review:
+                        </span>
+                    )}
 
                     {match.gameIds.length > 1 && match.gameIds.map((gid, i) => (
                         <Link key={gid} to={`/games/${gid}`} className="rounded bg-white/4 px-1.5 py-0.5 text-[9px] text-slate-500 transition hover:text-white">
@@ -1442,8 +1450,8 @@ function TournamentRoute() {
                                                             viewerProfileId={acct?.id ?? null}
                                                             timeoutAt={t.matchJoinTimeoutMinutes > 0 && m.waitingForPlayers && m.startedAt !== null ? m.startedAt + t.matchJoinTimeoutMinutes * 60_000 : null}
                                                             extensionMinutes={t.matchExtensionMinutes}
-                                                            pendingExtension={t.extensionRequests.find((r) => r.matchId === m.id && r.status === `pending`) ?? null}
-                                                            claimWinExpiresAt={null}
+                                                            pendingExtension={t.extensionRequests.find((r) => r.matchId === m.id && (r.gameNumber ?? 1) === m.currentGameNumber && r.status === `pending`) ?? null}
+                                                            claimWinExpiresAt={m.claimWinExpiresAt ?? null}
                                                             onOpen={(sid) => void nav(`/session/${sid}`)}
                                                             onWalkover={(mid, pid) => void run(() => awardTournamentWalkover(t.id, mid, pid), `Walkover.`)}
                                                             onReopen={(mid) => void run(() => reopenTournamentMatch(t.id, mid), `Reopened.`)}

--- a/packages/frontend/src/routes/TournamentRoute.tsx
+++ b/packages/frontend/src/routes/TournamentRoute.tsx
@@ -442,6 +442,7 @@ function getExitInfo(
     if (!elimMatch) return { label: ``, color: `default` };
 
     if (elimMatch.bracket === `grand-final` || elimMatch.bracket === `grand-final-reset`) return { label: `Grand Final`, color: `silver` };
+    if (elimMatch.bracket === `third-place`) return { label: `Third Place Match`, color: `default` };
 
     const totalRounds = Math.max(...matches.filter((m) => m.bracket === elimMatch.bracket).map((m) => m.round));
     const roundsFromEnd = totalRounds - elimMatch.round;

--- a/packages/frontend/src/routes/TournamentRoute.tsx
+++ b/packages/frontend/src/routes/TournamentRoute.tsx
@@ -857,8 +857,8 @@ function useCountdown(deadlineMs: number | null) {
 
 /* ── Match card ─────────────────────────────────────── */
 
-function MatchCard({ match, canManage, viewerProfileId, tournamentStatus, timeoutAt, extensionMinutes, pendingExtension, claimWinExpiresAt, onOpen, onWalkover, onReopen, onRequestExtension, onResolveExtension }: {
-    match: TournamentMatch; canManage: boolean; viewerProfileId: string | null; tournamentStatus: TournamentDetail[`status`]
+function MatchCard({ match, allMatches, canManage, viewerProfileId, tournamentStatus, timeoutAt, extensionMinutes, pendingExtension, claimWinExpiresAt, onOpen, onWalkover, onReopen, onRequestExtension, onResolveExtension }: {
+    match: TournamentMatch; allMatches: TournamentMatch[]; canManage: boolean; viewerProfileId: string | null; tournamentStatus: TournamentDetail[`status`]
     timeoutAt: number | null; extensionMinutes: number; pendingExtension: TournamentExtensionRequest | null; claimWinExpiresAt: number | null
     onOpen: (sid: string) => void; onWalkover: (mid: string, pid: string) => void; onReopen: (mid: string) => void
     onRequestExtension: (mid: string) => void; onResolveExtension: (eid: string, approve: boolean) => void
@@ -872,12 +872,13 @@ function MatchCard({ match, canManage, viewerProfileId, tournamentStatus, timeou
 
     const slot = (s: TournamentMatch[`slots`][number], wins: number, isW: boolean) => {
         const isTbd = !s.profileId && !s.isBye;
-        const sourceMatch = s.source && s.source.type !== `seed` ? s.source : null;
-        const canNavigate = isTbd && sourceMatch;
+        const sourceRef = s.source && s.source.type !== `seed` ? s.source : null;
+        const sourceMatchRecord = sourceRef ? allMatches.find((entry) => entry.id === sourceRef.matchId) ?? null : null;
+        const canNavigate = isTbd && sourceRef;
         return (
             <div
                 className={`flex items-center justify-between rounded px-2 py-1 ${isW ? `bg-emerald-400/8` : s.isBye ? `bg-white/2` : `bg-white/3`} ${canNavigate ? `cursor-pointer transition hover:bg-white/6` : ``}`}
-                onClick={canNavigate ? () => scrollToMatch(sourceMatch.matchId) : undefined}
+                onClick={canNavigate ? () => scrollToMatch(sourceRef.matchId) : undefined}
             >
                 <span className={`flex items-center gap-1.5 text-[12px] ${s.isBye ? `italic text-slate-600` : isTbd ? `italic text-slate-500` : isW ? `font-bold text-emerald-200` : `font-medium text-white`}`}>
                     {s.seed && <span className="text-[9px] text-slate-500">
@@ -885,10 +886,10 @@ function MatchCard({ match, canManage, viewerProfileId, tournamentStatus, timeou
                                </span>}
 
                     {s.displayName ?? `TBD`}
-                    {canNavigate && <span className="text-[9px] text-slate-600">
-                        {sourceMatch.type === `winner` ? `W` : `L`}
-                        {` of M`}
-                        {sourceMatch.matchId.split(`-`).at(-1)}
+                    {canNavigate && sourceMatchRecord && <span className="text-[9px] text-slate-600">
+                        {sourceRef.type === `winner` ? `W` : `L`}
+                        {` of R${sourceMatchRecord.round}M${sourceMatchRecord.order}`}
+                        {sourceMatchRecord.bracket === `losers` ? ` (LB)` : sourceMatchRecord.bracket === `grand-final` ? ` (GF)` : sourceMatchRecord.bracket === `grand-final-reset` ? ` (GF Reset)` : ``}
                                     </span>}
                 </span>
 
@@ -1433,7 +1434,7 @@ function TournamentRoute() {
                                                 <div className="grid gap-2 sm:grid-cols-2">
                                                     {matches.sort((a, b) => a.order - b.order).map((m) => (
                                                         <MatchCard
-                                                            key={m.id} match={m} canManage={t.viewer.canManage}
+                                                            key={m.id} match={m} allMatches={t.matches} canManage={t.viewer.canManage}
                                                             viewerProfileId={acct?.id ?? null}
                                                             tournamentStatus={t.status}
                                                             timeoutAt={t.matchJoinTimeoutMinutes > 0 && m.waitingForPlayers && m.startedAt !== null ? m.startedAt + t.matchJoinTimeoutMinutes * 60_000 : null}

--- a/packages/frontend/src/tournamentMultiviewStore.test.ts
+++ b/packages/frontend/src/tournamentMultiviewStore.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { useTournamentMultiviewStore } from './tournamentMultiviewStore';
+
+function resetStore() {
+    useTournamentMultiviewStore.setState({
+        activeTournamentId: null,
+        selectionsByTournament: {},
+        tilesBySessionId: {},
+    });
+}
+
+test(`multiview keeps a trimmed manual selection across reactivation`, () => {
+    resetStore();
+    const store = useTournamentMultiviewStore.getState();
+
+    store.activateTournament(`tournament-1`, [
+        `session-1`,
+        `session-2`,
+        `session-3`,
+    ]);
+    store.removeSession(`tournament-1`, `session-2`);
+    store.removeSession(`tournament-1`, `session-3`);
+    store.activateTournament(`tournament-1`, [
+        `session-1`,
+        `session-2`,
+        `session-3`,
+    ]);
+
+    assert.deepEqual(useTournamentMultiviewStore.getState().selectionsByTournament[`tournament-1`], [`session-1`]);
+});
+
+test(`multiview prunes unavailable sessions without auto-filling replacements`, () => {
+    resetStore();
+    const store = useTournamentMultiviewStore.getState();
+
+    store.activateTournament(`tournament-1`, [
+        `session-1`,
+        `session-2`,
+    ]);
+    store.activateTournament(`tournament-1`, [`session-1`]);
+
+    assert.deepEqual(useTournamentMultiviewStore.getState().selectionsByTournament[`tournament-1`], [`session-1`]);
+});

--- a/packages/frontend/src/tournamentMultiviewStore.ts
+++ b/packages/frontend/src/tournamentMultiviewStore.ts
@@ -80,19 +80,10 @@ export const useTournamentMultiviewStore = create<TournamentMultiviewStoreState>
     activateTournament: (tournamentId, eligibleSessionIds) => set((state) => {
         const hasStoredSelection = Object.prototype.hasOwnProperty.call(state.selectionsByTournament, tournamentId);
         const storedSelection = state.selectionsByTournament[tournamentId] ?? [];
-        let nextSelection = hasStoredSelection
+        const nextSelection = hasStoredSelection
             ? storedSelection.slice(0, TOURNAMENT_MULTIVIEW_MAX_TILES)
+                .filter((sessionId) => eligibleSessionIds.includes(sessionId))
             : eligibleSessionIds.slice(0, TOURNAMENT_MULTIVIEW_MAX_TILES);
-
-        if (hasStoredSelection) {
-            const eligibleSessionIdSet = new Set(eligibleSessionIds);
-            const liveSelection = nextSelection.filter((sessionId) => eligibleSessionIdSet.has(sessionId));
-            const additionalEligibleSessions = eligibleSessionIds.filter((sessionId) => !liveSelection.includes(sessionId));
-            nextSelection = [
-                ...liveSelection,
-                ...additionalEligibleSessions,
-            ].slice(0, TOURNAMENT_MULTIVIEW_MAX_TILES);
-        }
 
         if (
             state.activeTournamentId === tournamentId

--- a/packages/frontend/src/tournamentMultiviewStore.ts
+++ b/packages/frontend/src/tournamentMultiviewStore.ts
@@ -78,15 +78,29 @@ export const useTournamentMultiviewStore = create<TournamentMultiviewStoreState>
     tilesBySessionId: {},
 
     activateTournament: (tournamentId, eligibleSessionIds) => set((state) => {
-        if (state.activeTournamentId === tournamentId) {
-            return state;
-        }
-
         const hasStoredSelection = Object.prototype.hasOwnProperty.call(state.selectionsByTournament, tournamentId);
         const storedSelection = state.selectionsByTournament[tournamentId] ?? [];
-        const nextSelection = hasStoredSelection
+        let nextSelection = hasStoredSelection
             ? storedSelection.slice(0, TOURNAMENT_MULTIVIEW_MAX_TILES)
             : eligibleSessionIds.slice(0, TOURNAMENT_MULTIVIEW_MAX_TILES);
+
+        if (hasStoredSelection) {
+            const eligibleSessionIdSet = new Set(eligibleSessionIds);
+            const liveSelection = nextSelection.filter((sessionId) => eligibleSessionIdSet.has(sessionId));
+            const additionalEligibleSessions = eligibleSessionIds.filter((sessionId) => !liveSelection.includes(sessionId));
+            nextSelection = [
+                ...liveSelection,
+                ...additionalEligibleSessions,
+            ].slice(0, TOURNAMENT_MULTIVIEW_MAX_TILES);
+        }
+
+        if (
+            state.activeTournamentId === tournamentId
+            && nextSelection.length === storedSelection.length
+            && nextSelection.every((sessionId, index) => sessionId === storedSelection[index])
+        ) {
+            return state;
+        }
 
         return {
             activeTournamentId: tournamentId,

--- a/packages/frontend/src/utils/tournamentBracketConnectors.test.ts
+++ b/packages/frontend/src/utils/tournamentBracketConnectors.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { TournamentMatch, TournamentMatchSlot } from '@ih3t/shared';
+
+import { getBracketConnectorEdges } from './tournamentBracketConnectors';
+
+function createSlot(overrides: Partial<TournamentMatchSlot> = {}): TournamentMatchSlot {
+    return {
+        source: overrides.source ?? null,
+        profileId: overrides.profileId ?? null,
+        displayName: overrides.displayName ?? null,
+        image: overrides.image ?? null,
+        seed: overrides.seed ?? null,
+        isBye: overrides.isBye ?? false,
+    };
+}
+
+function createMatch(overrides: Partial<TournamentMatch> & Pick<TournamentMatch, `id` | `bracket` | `round` | `order`>): TournamentMatch {
+    return {
+        id: overrides.id,
+        bracket: overrides.bracket,
+        round: overrides.round,
+        order: overrides.order,
+        state: overrides.state ?? `pending`,
+        bestOf: overrides.bestOf ?? 1,
+        slots: overrides.slots ?? [createSlot(), createSlot()],
+        leftWins: overrides.leftWins ?? 0,
+        rightWins: overrides.rightWins ?? 0,
+        gameIds: overrides.gameIds ?? [],
+        sessionId: overrides.sessionId ?? null,
+        winnerProfileId: overrides.winnerProfileId ?? null,
+        loserProfileId: overrides.loserProfileId ?? null,
+        resultType: overrides.resultType ?? null,
+        currentGameNumber: overrides.currentGameNumber ?? 1,
+        startedAt: overrides.startedAt ?? null,
+        resolvedAt: overrides.resolvedAt ?? null,
+        advanceWinnerTo: overrides.advanceWinnerTo ?? null,
+        advanceLoserTo: overrides.advanceLoserTo ?? null,
+        claimWinExpiresAt: overrides.claimWinExpiresAt ?? null,
+        waitingForPlayers: overrides.waitingForPlayers ?? false,
+    };
+}
+
+test(`connectors only draw in-section losers dependencies`, () => {
+    const edges = getBracketConnectorEdges([
+        {
+            round: 1,
+            matches: [
+                createMatch({ id: `match-losers-1-1`, bracket: `losers`, round: 1, order: 1 }),
+                createMatch({ id: `match-losers-1-2`, bracket: `losers`, round: 1, order: 2 }),
+            ],
+        },
+        {
+            round: 2,
+            matches: [
+                createMatch({
+                    id: `match-losers-2-1`,
+                    bracket: `losers`,
+                    round: 2,
+                    order: 1,
+                    slots: [
+                        createSlot({ source: { type: `winner`, matchId: `match-losers-1-1` } }),
+                        createSlot({ source: { type: `loser`, matchId: `match-winners-2-1` } }),
+                    ],
+                }),
+                createMatch({
+                    id: `match-losers-2-2`,
+                    bracket: `losers`,
+                    round: 2,
+                    order: 2,
+                    slots: [
+                        createSlot({ source: { type: `winner`, matchId: `match-losers-1-2` } }),
+                        createSlot({ source: { type: `loser`, matchId: `match-winners-2-2` } }),
+                    ],
+                }),
+            ],
+        },
+    ]);
+
+    assert.deepEqual(edges, [
+        { sourceRoundIndex: 0, sourceMatchIndex: 0, targetRoundIndex: 1, targetMatchIndex: 0 },
+        { sourceRoundIndex: 0, sourceMatchIndex: 1, targetRoundIndex: 1, targetMatchIndex: 1 },
+    ]);
+});
+
+test(`connectors link grand-final resets back to the grand final`, () => {
+    const edges = getBracketConnectorEdges([
+        {
+            round: 1,
+            matches: [
+                createMatch({
+                    id: `match-grand-final-1-1`,
+                    bracket: `grand-final`,
+                    round: 1,
+                    order: 1,
+                }),
+            ],
+        },
+        {
+            round: 2,
+            matches: [
+                createMatch({
+                    id: `match-grand-final-reset-1-1`,
+                    bracket: `grand-final-reset`,
+                    round: 1,
+                    order: 1,
+                }),
+            ],
+        },
+    ]);
+
+    assert.deepEqual(edges, [
+        { sourceRoundIndex: 0, sourceMatchIndex: 0, targetRoundIndex: 1, targetMatchIndex: 0 },
+    ]);
+});

--- a/packages/frontend/src/utils/tournamentBracketConnectors.ts
+++ b/packages/frontend/src/utils/tournamentBracketConnectors.ts
@@ -1,0 +1,75 @@
+import type { TournamentMatch } from '@ih3t/shared';
+
+export type TournamentBracketRound = {
+    round: number
+    matches: TournamentMatch[]
+};
+
+export type TournamentBracketConnectorEdge = {
+    sourceRoundIndex: number
+    sourceMatchIndex: number
+    targetRoundIndex: number
+    targetMatchIndex: number
+};
+
+function getSourceMatchIds(rounds: TournamentBracketRound[], match: TournamentMatch): string[] {
+    const sourceMatchIds = match.slots.flatMap((slot) => {
+        const source = slot.source;
+        if (!source || source.type === `seed`) {
+            return [];
+        }
+
+        return [source.matchId];
+    });
+
+    if (sourceMatchIds.length > 0) {
+        return [...new Set(sourceMatchIds)];
+    }
+
+    if (match.bracket === `grand-final-reset`) {
+        const grandFinal = rounds.flatMap((round) => round.matches)
+            .find((entry) => entry.bracket === `grand-final`);
+        return grandFinal ? [grandFinal.id] : [];
+    }
+
+    return [];
+}
+
+export function getBracketConnectorEdges(rounds: TournamentBracketRound[]): TournamentBracketConnectorEdge[] {
+    const sortedRounds = rounds.map((round) => ({
+        round: round.round,
+        matches: [...round.matches].sort((left, right) => left.order - right.order),
+    }));
+    const matchIndexById = new Map<string, { roundIndex: number; matchIndex: number }>();
+
+    sortedRounds.forEach((round, roundIndex) => {
+        round.matches.forEach((match, matchIndex) => {
+            matchIndexById.set(match.id, {
+                roundIndex,
+                matchIndex,
+            });
+        });
+    });
+
+    const edges: TournamentBracketConnectorEdge[] = [];
+    sortedRounds.forEach((round, targetRoundIndex) => {
+        round.matches.forEach((match, targetMatchIndex) => {
+            const sourceMatches = getSourceMatchIds(sortedRounds, match);
+            sourceMatches.forEach((sourceMatchId) => {
+                const sourceIndex = matchIndexById.get(sourceMatchId);
+                if (!sourceIndex || sourceIndex.roundIndex >= targetRoundIndex) {
+                    return;
+                }
+
+                edges.push({
+                    sourceRoundIndex: sourceIndex.roundIndex,
+                    sourceMatchIndex: sourceIndex.matchIndex,
+                    targetRoundIndex,
+                    targetMatchIndex,
+                });
+            });
+        });
+    });
+
+    return edges;
+}

--- a/packages/frontend/src/utils/tournamentMatchSessionAccess.test.ts
+++ b/packages/frontend/src/utils/tournamentMatchSessionAccess.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { TournamentMatch } from '@ih3t/shared';
+
+import { getTournamentMatchSessionAccess } from './tournamentMatchSessionAccess';
+
+function createMatch(overrides: Partial<TournamentMatch> & Pick<TournamentMatch, `id` | `bracket` | `round` | `order`>): TournamentMatch {
+    return {
+        id: overrides.id,
+        bracket: overrides.bracket,
+        round: overrides.round,
+        order: overrides.order,
+        state: overrides.state ?? `pending`,
+        bestOf: overrides.bestOf ?? 1,
+        slots: overrides.slots ?? [
+            { source: null, profileId: null, displayName: null, image: null, seed: null, isBye: false },
+            { source: null, profileId: null, displayName: null, image: null, seed: null, isBye: false },
+        ],
+        leftWins: overrides.leftWins ?? 0,
+        rightWins: overrides.rightWins ?? 0,
+        gameIds: overrides.gameIds ?? [],
+        sessionId: overrides.sessionId ?? null,
+        winnerProfileId: overrides.winnerProfileId ?? null,
+        loserProfileId: overrides.loserProfileId ?? null,
+        resultType: overrides.resultType ?? null,
+        currentGameNumber: overrides.currentGameNumber ?? 1,
+        startedAt: overrides.startedAt ?? null,
+        claimWinExpiresAt: overrides.claimWinExpiresAt ?? null,
+        resolvedAt: overrides.resolvedAt ?? null,
+        advanceWinnerTo: overrides.advanceWinnerTo ?? null,
+        advanceLoserTo: overrides.advanceLoserTo ?? null,
+        waitingForPlayers: overrides.waitingForPlayers ?? false,
+    };
+}
+
+test(`live tournament participants can still join their match session`, () => {
+    const match = createMatch({
+        id: `match-winners-1-1`,
+        bracket: `winners`,
+        round: 1,
+        order: 1,
+        state: `ready`,
+        sessionId: `session-live`,
+        slots: [
+            { source: null, profileId: `player-1`, displayName: `Player 1`, image: null, seed: 1, isBye: false },
+            { source: null, profileId: `player-2`, displayName: `Player 2`, image: null, seed: 2, isBye: false },
+        ],
+    });
+
+    assert.deepEqual(getTournamentMatchSessionAccess(`live`, match, `player-1`), {
+        isParticipant: true,
+        canJoin: true,
+        canSpectate: false,
+    });
+});
+
+test(`cancelled tournaments do not expose join or spectate links`, () => {
+    const match = createMatch({
+        id: `match-winners-1-1`,
+        bracket: `winners`,
+        round: 1,
+        order: 1,
+        state: `in-progress`,
+        sessionId: `session-cancelled`,
+        startedAt: Date.now() - 60_000,
+        slots: [
+            { source: null, profileId: `player-1`, displayName: `Player 1`, image: null, seed: 1, isBye: false },
+            { source: null, profileId: `player-2`, displayName: `Player 2`, image: null, seed: 2, isBye: false },
+        ],
+    });
+
+    assert.deepEqual(getTournamentMatchSessionAccess(`cancelled`, match, `spectator-1`), {
+        isParticipant: false,
+        canJoin: false,
+        canSpectate: false,
+    });
+    assert.deepEqual(getTournamentMatchSessionAccess(`cancelled`, match, `player-1`), {
+        isParticipant: true,
+        canJoin: false,
+        canSpectate: false,
+    });
+});

--- a/packages/frontend/src/utils/tournamentMatchSessionAccess.ts
+++ b/packages/frontend/src/utils/tournamentMatchSessionAccess.ts
@@ -1,0 +1,24 @@
+import type { TournamentMatch, TournamentStatus } from '@ih3t/shared';
+
+export type TournamentMatchSessionAccess = {
+    isParticipant: boolean
+    canJoin: boolean
+    canSpectate: boolean
+};
+
+export function getTournamentMatchSessionAccess(
+    tournamentStatus: TournamentStatus,
+    match: TournamentMatch,
+    viewerProfileId: string | null,
+): TournamentMatchSessionAccess {
+    const isParticipant = Boolean(viewerProfileId && match.slots.some((slot) => slot.profileId === viewerProfileId));
+    const canAccessSession = tournamentStatus === `live` && Boolean(match.sessionId);
+    const canJoin = canAccessSession && isParticipant && (match.state === `ready` || match.state === `in-progress`);
+    const canSpectate = canAccessSession && !isParticipant && match.state === `in-progress` && match.startedAt !== null;
+
+    return {
+        isParticipant,
+        canJoin,
+        canSpectate,
+    };
+}

--- a/packages/frontend/src/utils/tournamentRoundDelay.test.ts
+++ b/packages/frontend/src/utils/tournamentRoundDelay.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { TournamentDetail, TournamentMatch } from '@ih3t/shared';
+
+import { getRoundDelayCountdownState } from './tournamentRoundDelay';
+
+function createMatch(overrides: Partial<TournamentMatch> & Pick<TournamentMatch, `id` | `bracket` | `round` | `order`>): TournamentMatch {
+    return {
+        id: overrides.id,
+        bracket: overrides.bracket,
+        round: overrides.round,
+        order: overrides.order,
+        state: overrides.state ?? `pending`,
+        bestOf: overrides.bestOf ?? 1,
+        slots: overrides.slots ?? [
+            { source: null, profileId: null, displayName: null, image: null, seed: null, isBye: false },
+            { source: null, profileId: null, displayName: null, image: null, seed: null, isBye: false },
+        ],
+        leftWins: overrides.leftWins ?? 0,
+        rightWins: overrides.rightWins ?? 0,
+        gameIds: overrides.gameIds ?? [],
+        sessionId: overrides.sessionId ?? null,
+        winnerProfileId: overrides.winnerProfileId ?? null,
+        loserProfileId: overrides.loserProfileId ?? null,
+        resultType: overrides.resultType ?? null,
+        currentGameNumber: overrides.currentGameNumber ?? 1,
+        startedAt: overrides.startedAt ?? null,
+        claimWinExpiresAt: overrides.claimWinExpiresAt ?? null,
+        resolvedAt: overrides.resolvedAt ?? null,
+        advanceWinnerTo: overrides.advanceWinnerTo ?? null,
+        advanceLoserTo: overrides.advanceLoserTo ?? null,
+        waitingForPlayers: overrides.waitingForPlayers ?? false,
+    };
+}
+
+function createTournament(matches: TournamentMatch[], roundDelayMinutes: number): Pick<TournamentDetail, `status` | `roundDelayMinutes` | `matches`> {
+    return {
+        status: `live`,
+        roundDelayMinutes,
+        matches,
+    };
+}
+
+test(`countdown uses both prerequisites for even losers rounds`, () => {
+    const now = 1_000_000;
+    const countdown = getRoundDelayCountdownState(createTournament([
+        createMatch({
+            id: `match-losers-1-1`,
+            bracket: `losers`,
+            round: 1,
+            order: 1,
+            state: `completed`,
+            resolvedAt: now - 9 * 60_000,
+        }),
+        createMatch({
+            id: `match-winners-2-1`,
+            bracket: `winners`,
+            round: 2,
+            order: 1,
+            state: `completed`,
+            resolvedAt: now - 2 * 60_000,
+        }),
+        createMatch({
+            id: `match-losers-2-1`,
+            bracket: `losers`,
+            round: 2,
+            order: 1,
+            slots: [
+                { source: { type: `winner`, matchId: `match-losers-1-1` }, profileId: null, displayName: null, image: null, seed: null, isBye: false },
+                { source: { type: `loser`, matchId: `match-winners-2-1` }, profileId: null, displayName: null, image: null, seed: null, isBye: false },
+            ],
+        }),
+    ], 5), now);
+
+    assert.ok(countdown);
+    assert.equal(countdown.matchId, `match-losers-2-1`);
+    assert.equal(countdown.remainingMs, 3 * 60_000);
+});
+
+test(`countdown uses the grand final as the reset dependency`, () => {
+    const now = 2_000_000;
+    const countdown = getRoundDelayCountdownState(createTournament([
+        createMatch({
+            id: `match-grand-final-1-1`,
+            bracket: `grand-final`,
+            round: 1,
+            order: 1,
+            state: `completed`,
+            resolvedAt: now - 60_000,
+        }),
+        createMatch({
+            id: `match-grand-final-reset-1-1`,
+            bracket: `grand-final-reset`,
+            round: 1,
+            order: 1,
+        }),
+    ], 4), now);
+
+    assert.ok(countdown);
+    assert.equal(countdown.matchId, `match-grand-final-reset-1-1`);
+    assert.equal(countdown.remainingMs, 3 * 60_000);
+});

--- a/packages/frontend/src/utils/tournamentRoundDelay.ts
+++ b/packages/frontend/src/utils/tournamentRoundDelay.ts
@@ -1,0 +1,74 @@
+import type { TournamentDetail, TournamentMatch } from '@ih3t/shared';
+
+export type TournamentRoundDelayCountdownState = {
+    matchId: string
+    readyAt: number
+    remainingMs: number
+};
+
+function getRoundDelayDependencyMatches(matches: TournamentMatch[], match: TournamentMatch): TournamentMatch[] {
+    if (match.bracket === `grand-final-reset`) {
+        return matches.filter((entry) => entry.bracket === `grand-final`);
+    }
+
+    const dependencyIds = new Set(match.slots.flatMap((slot) => {
+        const source = slot.source;
+        if (!source || source.type === `seed`) {
+            return [];
+        }
+
+        return [source.matchId];
+    }));
+    if (dependencyIds.size > 0) {
+        return matches.filter((entry) => dependencyIds.has(entry.id));
+    }
+
+    if (match.round <= 1) {
+        return [];
+    }
+
+    return matches.filter((entry) => entry.bracket === match.bracket && entry.round === match.round - 1);
+}
+
+export function getRoundDelayCountdownState(
+    tournament: Pick<TournamentDetail, `status` | `roundDelayMinutes` | `matches`>,
+    now = Date.now(),
+): TournamentRoundDelayCountdownState | null {
+    if (tournament.status !== `live` || tournament.roundDelayMinutes <= 0) {
+        return null;
+    }
+
+    const delayMs = tournament.roundDelayMinutes * 60_000;
+    let bestCountdown: TournamentRoundDelayCountdownState | null = null;
+
+    for (const match of tournament.matches) {
+        if (match.state !== `pending`) {
+            continue;
+        }
+
+        const dependencyMatches = getRoundDelayDependencyMatches(tournament.matches, match);
+        if (dependencyMatches.length === 0 || !dependencyMatches.every((entry) => entry.state === `completed`)) {
+            continue;
+        }
+
+        const latestResolvedAt = Math.max(...dependencyMatches.map((entry) => entry.resolvedAt ?? 0));
+        const readyAt = latestResolvedAt + delayMs;
+        if (readyAt <= now) {
+            continue;
+        }
+
+        if (
+            !bestCountdown
+            || readyAt < bestCountdown.readyAt
+            || (readyAt === bestCountdown.readyAt && match.id < bestCountdown.matchId)
+        ) {
+            bestCountdown = {
+                matchId: match.id,
+                readyAt,
+                remainingMs: readyAt - now,
+            };
+        }
+    }
+
+    return bestCountdown;
+}

--- a/packages/shared/src/tournaments.ts
+++ b/packages/shared/src/tournaments.ts
@@ -569,7 +569,7 @@ export const zSessionTournamentInfo = z.object({
     matchExtensionMs: z.number().int()
         .nonnegative(),
     pendingExtension: z.boolean(),
-    matchStartedAt: zTimestamp,
+    matchJoinTimeoutInMs: z.number().int().nullable(),
     leftDisplayName: z.string().nullable(),
     rightDisplayName: z.string().nullable(),
     leftProfileId: zIdentifier.nullable(),
@@ -617,7 +617,7 @@ export const zMatchClaimWinState = z.object({
         .positive(),
     claimantProfileId: zIdentifier,
     startedAt: zTimestamp,
-    expiresAt: zTimestamp,
+    expiresInMs: z.number().int().nonnegative(),
 });
 export type MatchClaimWinState = z.infer<typeof zMatchClaimWinState>;
 

--- a/packages/shared/src/tournaments.ts
+++ b/packages/shared/src/tournaments.ts
@@ -568,6 +568,7 @@ export const zSessionTournamentInfo = z.object({
         .nonnegative(),
     matchExtensionMs: z.number().int()
         .nonnegative(),
+    pendingExtension: z.boolean(),
     matchStartedAt: zTimestamp,
     leftDisplayName: z.string().nullable(),
     rightDisplayName: z.string().nullable(),

--- a/packages/shared/src/tournaments.ts
+++ b/packages/shared/src/tournaments.ts
@@ -193,6 +193,7 @@ export const zTournamentMatch = z.object({
         .positive()
         .default(1),
     startedAt: zTimestamp.nullable(),
+    claimWinExpiresAt: zTimestamp.nullable().optional(),
     resolvedAt: zTimestamp.nullable(),
     advanceWinnerTo: zTournamentMatchAdvanceTarget.nullable(),
     advanceLoserTo: zTournamentMatchAdvanceTarget.nullable(),
@@ -342,6 +343,9 @@ export type TournamentExtensionStatus = z.infer<typeof zTournamentExtensionStatu
 export const zTournamentExtensionRequest = z.object({
     id: zIdentifier,
     matchId: zIdentifier,
+    gameNumber: z.number().int()
+        .positive()
+        .default(1),
     requestedByProfileId: zIdentifier,
     requestedByDisplayName: z.string(),
     requestedAt: zTimestamp,
@@ -606,6 +610,8 @@ export type ClaimWinRequest = z.infer<typeof zClaimWinRequest>;
 
 export const zMatchClaimWinState = z.object({
     matchId: zIdentifier,
+    gameNumber: z.number().int()
+        .positive(),
     claimantProfileId: zIdentifier,
     startedAt: zTimestamp,
     expiresAt: zTimestamp,

--- a/packages/shared/src/tournaments.ts
+++ b/packages/shared/src/tournaments.ts
@@ -572,6 +572,8 @@ export const zSessionTournamentInfo = z.object({
     matchStartedAt: zTimestamp,
     leftDisplayName: z.string().nullable(),
     rightDisplayName: z.string().nullable(),
+    leftProfileId: zIdentifier.nullable(),
+    rightProfileId: zIdentifier.nullable(),
 });
 export type SessionTournamentInfo = z.infer<typeof zSessionTournamentInfo>;
 


### PR DESCRIPTION
A batch of follow-up fixes and small polish commits for the tournament system landed in #80.

## Commits

### Bug fixes
- **fix: scope tournament best-of state per game** — best-of series now track per-game state independently so restarts don't leak across games.
- **fix: improve tournament best-of match actions** — action availability now reflects the correct game slot within a series.
- **fix: keep tournament multiview synced across best-of games** — multiview tiles refresh when a new game in a series starts.
- **fix: correct tournament placement and timeout tracking** — final placements and join-timeout progress stay consistent after restarts.
- **fix: improve single-elimination tournament views** — corrects the bracket/detail rendering for single-elim edge cases.
- **fix: close tournament waitlist edge cases** — waitlist window close/drop paths no longer leave tournaments in limbo.
- **fix: protect tournament detail and claim updates** — concurrent claim-win and detail updates are serialized per tournament.
- **fix: respect tournament round delays** — round delay cooldowns are enforced correctly between bracket rounds.
- **fix: preserve tournament format edits on rerender** — editor form no longer clobbers in-progress format changes.
- **fix: harden tournament reconciliation and swiss pairing** — swiss pairing and reconciliation are more robust to dropouts.
- **fix: harden tournament state synchronization** — tightens tournament↔session state sync paths.
- **fix: allow dev frontend on port 5174** — adds 5174 to CORS allow-list for local dev.
- **fix: relax swiss pairings when rematches are unavoidable** — swiss falls back to minimal rematches (oldest rounds first) instead of failing to pair.
- **fix: clear session info when reopening tournament match** — `reopenMatch` now clears the old session's tournament context to prevent stale state.
- **fix: re-warn timed out matches after extension expires** — the "already warned" check now floors the window at the latest approved extension's resolvedAt, so players get re-notified when their extension runs out.
- **fix: hide pre-start leavers from tournament standings** — players who withdrew or didn't check in before the tournament started are hidden from standings and the DQ list (they only appear as "removed" now).
- **fix: match tournament opponent by profile id** — waiting screen now matches the local player against the match slots by profile id instead of display name, so name changes don't break opponent detection.
- **fix: send relative tournament timer durations to clients** — join timeout and claim-win deadlines are sent as remaining-ms values and anchored to `Date.now()` on the client, preventing clock-skew drift.

### Additions
- **feat: label tbd slots with their source match** — TBD slots in the bracket/detail views now show "W of M3" / "L of M5" so players can tell where their future opponent is coming from.
- **feat: add 16-player seal bot tournament dev shortcuts** — dev-only buttons to spin up 16-player Swiss / Single Elim / Double Elim tournaments auto-played by seal bots.