### PR TITLE
fix for old replays

### DIFF
--- a/packages/backend/src/persistence/gameHistoryRepository.test.ts
+++ b/packages/backend/src/persistence/gameHistoryRepository.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import { zDatabaseGame, zFinishedGameRecord } from '@ih3t/shared';
 
-void test(`parses legacy tournament replay records without live timeout fields`, () => {
+test(`parses legacy tournament replay records with defaulted timeout, pending extension, and profile fields`, () => {
     const legacyTournamentGame = {
         id: `game-1`,
         version: 3,

--- a/packages/backend/src/persistence/gameHistoryRepository.test.ts
+++ b/packages/backend/src/persistence/gameHistoryRepository.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { zDatabaseGame, zFinishedGameRecord } from '@ih3t/shared';
+
+void test(`parses legacy tournament replay records without live timeout fields`, () => {
+    const legacyTournamentGame = {
+        id: `game-1`,
+        version: 3,
+        sessionId: `session-1`,
+        startedAt: 1_700_000_000_000,
+        finishedAt: 1_700_000_120_000,
+        players: [
+            {
+                playerId: `player-left`,
+                displayName: `Left`,
+                profileId: `profile-left`,
+                elo: null,
+                eloChange: null,
+            },
+            {
+                playerId: `player-right`,
+                displayName: `Right`,
+                profileId: `profile-right`,
+                elo: null,
+                eloChange: null,
+            },
+        ],
+        playerTiles: {
+            'player-left': { color: `#fbbf24` },
+            'player-right': { color: `#38bdf8` },
+        },
+        gameOptions: {
+            visibility: `public`,
+            rated: false,
+            firstPlayer: `random`,
+            timeControl: {
+                mode: `unlimited`,
+            },
+        },
+        moves: [],
+        moveCount: 0,
+        gameResult: {
+            winningPlayerId: `player-left`,
+            durationMs: 120_000,
+            reason: `six-in-a-row`,
+        },
+        tournament: {
+            tournamentId: `tournament-1`,
+            tournamentName: `Spring Major`,
+            matchId: `match-1`,
+            bracket: `winners`,
+            round: 1,
+            order: 1,
+            bestOf: 1,
+            currentGameNumber: 1,
+            leftWins: 1,
+            rightWins: 0,
+            matchJoinTimeoutMs: 300_000,
+            matchExtensionMs: 300_000,
+            leftDisplayName: `Left`,
+            rightDisplayName: `Right`,
+            resultType: `played`,
+        },
+    };
+
+    const parsedDatabaseGame = zDatabaseGame.parse(legacyTournamentGame);
+    assert.equal(parsedDatabaseGame.tournament?.pendingExtension, false);
+    assert.equal(parsedDatabaseGame.tournament?.matchJoinTimeoutInMs, null);
+    assert.equal(parsedDatabaseGame.tournament?.leftProfileId, null);
+    assert.equal(parsedDatabaseGame.tournament?.rightProfileId, null);
+
+    const parsedReplay = zFinishedGameRecord.parse(parsedDatabaseGame);
+    assert.equal(parsedReplay.tournament?.pendingExtension, false);
+    assert.equal(parsedReplay.tournament?.matchJoinTimeoutInMs, null);
+    assert.equal(parsedReplay.tournament?.leftProfileId, null);
+    assert.equal(parsedReplay.tournament?.rightProfileId, null);
+});

--- a/packages/shared/src/tournaments.ts
+++ b/packages/shared/src/tournaments.ts
@@ -568,12 +568,16 @@ export const zSessionTournamentInfo = z.object({
         .nonnegative(),
     matchExtensionMs: z.number().int()
         .nonnegative(),
-    pendingExtension: z.boolean(),
-    matchJoinTimeoutInMs: z.number().int().nullable(),
+    pendingExtension: z.boolean().default(false),
+    matchJoinTimeoutInMs: z.number().int()
+        .nullable()
+        .default(null),
     leftDisplayName: z.string().nullable(),
     rightDisplayName: z.string().nullable(),
-    leftProfileId: zIdentifier.nullable(),
-    rightProfileId: zIdentifier.nullable(),
+    leftProfileId: zIdentifier.nullable()
+        .default(null),
+    rightProfileId: zIdentifier.nullable()
+        .default(null),
 });
 export type SessionTournamentInfo = z.infer<typeof zSessionTournamentInfo>;
 

--- a/packages/shared/src/tournaments.ts
+++ b/packages/shared/src/tournaments.ts
@@ -570,6 +570,7 @@ export const zSessionTournamentInfo = z.object({
         .nonnegative(),
     pendingExtension: z.boolean().default(false),
     matchJoinTimeoutInMs: z.number().int()
+        .nonnegative()
         .nullable()
         .default(null),
     leftDisplayName: z.string().nullable(),


### PR DESCRIPTION
## Summary
- Restore loading of legacy tournament replays whose persisted records predate four newer `SessionTournamentInfo` fields
- Add defaults in the shared Zod schema (`pendingExtension` → `false`, `matchJoinTimeoutInMs` → `null`, `leftProfileId` / `rightProfileId` → `null`) so old records parse cleanly through both `zDatabaseGame` and `zFinishedGameRecord`
- Add a regression test covering a legacy tournament game record without those fields